### PR TITLE
Format code with ESLint and Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,12 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "rules": {
-    }
+  env: {
+    node: true,
+    es2021: true,
+  },
+  extends: 'eslint:recommended',
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: 'module',
+  },
+  rules: {},
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
 # Homebridge-Rituals
+
 v1 is functional release, ENJOY!!
 
-<img src="https://img.shields.io/badge/stage-stable-green"> <img src="https://img.shields.io/badge/completion-90%25-yellow"> <img src="https://img.shields.io/badge/license-MIT-green"> <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=4YXRZVGSVNAEE&item_name=Just+for+a+coffe&currency_code=EUR&source=url"><img src="https://img.shields.io/static/v1?label=Buy%20me%20a%20coffe&message=using%20paypal&color=green"></a> <a align="right" href="https://github.com/myluna08/homebridge-rituals/blob/master/README.md">English</a>|<a align="right" href="https://github.com/myluna08/homebridge-rituals/blob/master/README_ES.md">Español</a>
+<img src="https://img.shields.io/badge/stage-stable-green"> <img src="https://img.shields.io/badge/completion-90%25-yellow"> <img src="https://img.shields.io/badge/license-MIT-green"> <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=4YXRZVGSVNAEE&item_name=Just+for+a+coffe&currency_code=EUR&source=url"><img src="https://img.shields.io/static/v1?label=Buy%20me%20a%20coffee&message=using%20paypal&color=green"></a> <a align="right" href="https://github.com/myluna08/homebridge-rituals/blob/master/README.md">English</a>|<a align="right" href="https://github.com/myluna08/homebridge-rituals/blob/master/README_ES.md">Español</a>
 
 <img src="https://user-images.githubusercontent.com/19808920/58770949-bd9c7900-857f-11e9-8558-5dfaffddffda.png" height="100"> <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRoyOlRgCEZSyCrf2Ika_luW6N9ridvyC1Genb49xCQyLbc5eMG&s" height="90" align="right"> <img src="https://www.rituals.com/dw/image/v2/BBKL_PRD/on/demandware.static/-/Sites-rituals-products/default/dw7656c020/images/zoom/1106834_WirelessperfumeDiffuserPROAPrimary.png?sw=500&sh=500&sm=fit&q=100" height="100" align="right">
 
-Homebridge Rituals is a homebridge-plugin to manage a Rituals Genie over homebridge infraestructure.
+Homebridge Rituals is a homebridge-plugin to manage a Rituals Genie over homebridge infrastructure.
 Homebridge is a lightweight NodeJS server you can run on your home network that emulates the iOS HomeKit API.
 
 Since Siri supports devices added through HomeKit, this means that with Homebridge you can ask Siri to control devices that don't have any support for HomeKit at all. For instance, using just some of the available plugins, you can say:
 
 With this plugin you can do
 
- * _Siri, turn on the Genie._
- * _Siri, turn off the Genie._
-
+- _Siri, turn on the Genie._
+- _Siri, turn off the Genie._
 
 #### Before begin, (assumptions)
-* Your genie has been registered using Official Rituals App.
-* Your genie is working fine. (obviously)
-* Your <a href="https://github.com/nfarina/homebridge">homebridge</a> is working fine and has been added to your home app as bridge. If not, please take a look to <a href="#considerations">Installation from zero</a>.
+
+- Your genie has been registered using Official Rituals App.
+- Your genie is working fine. (obviously)
+- Your <a href="https://github.com/nfarina/homebridge">homebridge</a> is working fine and has been added to your home app as bridge. If not, please take a look to <a href="#considerations">Installation from zero</a>.
+
 Find more about on <a href="https://www.rituals.com/es-es/faqs.html?catid=faq-perfume-genie&qid=fag-what-is-the-perfume-genie-and-what-can-it-do">Official Rituals Site</a>
 
-## 01.Installation
+## 01. Installation
+
 With npm -i or if you are using manual plugin module installation.
+
 ```sh
 npm -i homebridge-rituals
 ```
+
 Otherwise you can use throught Homebridge UI-X the plugin search engine and just write : "homebridge-rituals" or "rituals" and click INSTALL
 
-## <a name="considerations"></a>02.Installation from zero
+## 02. Installation from zero
+
 0. This plugin is under development, (Unstable installation 0.0.x) (**stable installation 1.0.0 or greather..**)
 1. **Node v4.3.2 or greater is required.** Check by running: `node --version`. The plugins you use may require newer versions.
 2. **On Linux only:** Install the libavahi-compat-libdnssd-dev package: `sudo apt-get install libavahi-compat-libdnssd-dev`
@@ -37,16 +43,19 @@ Otherwise you can use throught Homebridge UI-X the plugin search engine and just
 4. Install the plugins using: `npm install -g <plugin-name>`
 5. Create the `config.json` file.
 
-## 03.Configuration in config.json
+## 03. Configuration in config.json
 
 FOR 1 GENIE ONLY
 One installed, you must modify your config.json file and add the following data:
+
 1. accessory (Required) = "Rituals"
 2. account (Required) = "xxxx@xxx.com" < that is the mail you are using in Rituals App Registration.
 3. password (Required) = "yyyyyyyy" < that is the password you are using in Rituals App.
 4. name (Optional) = "my Genie" < a name that you can assign, if not, "Genie" name has been assigned.
+
 SAVE your config.json file and RESTART homebridge.
-```
+
+```json
     "accessories": [
         {
             "accessory": "Rituals",
@@ -61,7 +70,8 @@ MULTIPLE GENIES IN YOUR account
 If you have more than one genie in your account, use the standard config for the first time and see the LOG. The Genie identifiers should appear in the log. Then add the "hub" key in the config to indicate what genie you want to control.
 
 1. Declare standard mode
-```
+
+```json
     "accessories": [
         {
             "accessory": "Rituals",
@@ -71,7 +81,9 @@ If you have more than one genie in your account, use the standard config for the
         }
     ],
 ```
+
 2. Wait for the LOG , like this..
+
 ```
 [7/1/2020, 1:24:44 PM] [Genie] Hub NOT validated!
 [7/1/2020, 1:24:44 PM] [Genie] There are multiple hubs found on your account
@@ -89,8 +101,10 @@ If you have more than one genie in your account, use the standard config for the
 [7/1/2020, 1:24:44 PM] [Genie] Hub: a0123456789a0123456789a0123456789a0123456789a0123456789a01234567
 [7/1/2020, 1:24:44 PM] [Genie] Key: 1
 ```
+
 3. declare every accesory with the correspondent hub identifier
-```
+
+```json
 "accessories": [
     {
         "accessory": "Rituals",
@@ -108,46 +122,52 @@ If you have more than one genie in your account, use the standard config for the
     }
 ],
 ```
+
 4. Restart Homebridge
 
-## 04.Limitations
-* It will appears in you home app like a Fan Accessory.
-* You can control start/stop.
-* Fan control is not available in this release (see changelog).
-* You can't see other properties like in the app, maybe later.
-* The most important limitation, with this very first version you can only manage only 1 genie under the rituals account.
+## 04. Limitations
 
-## 05.Following Features Implementation (Nice to have in the future)
+- It will appears in you home app like a Fan Accessory.
+- You can control start/stop.
+- Fan control is not available in this release (see changelog).
+- You can't see other properties like in the app, maybe later.
+- The most important limitation, with this very first version you can only manage only 1 genie under the rituals account.
+
+## 05. Following Features Implementation (Nice to have in the future)
+
 - [x] Allow to control FAN rotator speed, Done!
 - [x] Allow to show battery level information, Done!
 - [x] Detection of Genie version 1.0 or 2.0 (Genie 2.0 does not have battery, accessory battery not shown)
 - [x] Added Debug traces
-- [X] Allow to show the fragance name
+- [x] Allow to show the fragance name
 - [ ] Allow to show the fragance quantity remains inside genie ¿?
 - [x] Allow to manage more than one genie if you can more than one in the same rituals account.
 
-Yeah, many work .. but you can helpme with a coffe .. <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=4YXRZVGSVNAEE&item_name=Just+for+a+coffe&currency_code=EUR&source=url"><img src="https://img.shields.io/static/v1?label=Buy%20me%20a%20coffe&message=using%20paypal&color=green"></a>
+Yeah, many work .. but you can helpme with a coffee .. <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=4YXRZVGSVNAEE&item_name=Just+for+a+coffee&currency_code=EUR&source=url"><img src="https://img.shields.io/static/v1?label=Buy%20me%20a%20coffe&message=using%20paypal&color=green"></a>
 
-## 06.Credits && Trademarks
+## 06. Credits && Trademarks
+
 Rituals & Genie are registered trademarks of Rituals Cosmetics Enterprise B.V.
 
-## 07.ChangeLog
-* 1.1.9 Added control if Rituals Servers are down.
-* 1.1.8 fix mistake
-* 1.1.7 fix HUB in only one genie
-* 1.1.6 fix UUID for persistance.
-* 1.1.5 fix over log functions & fragance added.
-* 1.1.4 force change UUID to avoid same
-* 1.1.3 fix a defect with key with 1 genie only.
-* 1.1.2 fix a defect with package.json in some cases.
-* 1.1.1 Error ReferenceError: config is not defined solved.
-* 1.1.0 adding debug traces, support more than 1 genie in your account and current version of genie 1.0 or 2.0, fragance only in (homebridge)
-* 1.0.8 fix error using functions exposed by homebridge and adding new characteristic to use FAN rotator speed.
-* 1.0.7 wrong, unstable version!
-* 1.0.6 fix error with secure store, in some cases appears in homebridge logs permission errors.
-* 1.0.5 too many logins to get hash, implementing secure store.
-* 1.0.4 first release functional
-* 1.0.3 fix errors on request, json bad fomatted
-* 1.0.2 fix errors on_state, active_state
-* 1.0.1 scheme works but nothing do
-* 1.0.0 accessory registered successfully
+## 07. ChangeLog
+
+- 1.1.10 Add linting and fix up reference errors
+- 1.1.9 Added control if Rituals Servers are down.
+- 1.1.8 fix mistake
+- 1.1.7 fix HUB in only one genie
+- 1.1.6 fix UUID for persistance.
+- 1.1.5 fix over log functions & fragance added.
+- 1.1.4 force change UUID to avoid same
+- 1.1.3 fix a defect with key with 1 genie only.
+- 1.1.2 fix a defect with package.json in some cases.
+- 1.1.1 Error ReferenceError: config is not defined solved.
+- 1.1.0 adding debug traces, support more than 1 genie in your account and current version of genie 1.0 or 2.0, fragance only in (homebridge)
+- 1.0.8 fix error using functions exposed by homebridge and adding new characteristic to use FAN rotator speed.
+- 1.0.7 wrong, unstable version!
+- 1.0.6 fix error with secure store, in some cases appears in homebridge logs permission errors.
+- 1.0.5 too many logins to get hash, implementing secure store.
+- 1.0.4 first release functional
+- 1.0.3 fix errors on request, json bad fomatted
+- 1.0.2 fix errors on_state, active_state
+- 1.0.1 scheme works but nothing do
+- 1.0.0 accessory registered successfully

--- a/index.js
+++ b/index.js
@@ -14,293 +14,428 @@ let Service;
 let Characteristic;
 let logger;
 
-module.exports = function(homebridge) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    homebridge.registerAccessory('homebridge-rituals', 'Rituals', RitualsAccessory);
-}
+module.exports = function (homebridge) {
+  Service = homebridge.hap.Service;
+  Characteristic = homebridge.hap.Characteristic;
+  homebridge.registerAccessory(
+    'homebridge-rituals',
+    'Rituals',
+    RitualsAccessory
+  );
+};
 
 function RitualsAccessory(log, config) {
-    //logger = log;
-    this.log = log;
-    this.services = [];
-    this.hub = config.hub || '';
-    var dt = Math.floor(Math.random() * 10000) + 1;
+  //logger = log;
+  this.log = log;
+  this.services = [];
+  this.hub = config.hub || '';
+  var dt = Math.floor(Math.random() * 10000) + 1;
 
-    this.log.debug('RitualsAccesory -> init :: RitualsAccessory(log, config)');
+  this.log.debug('RitualsAccesory -> init :: RitualsAccessory(log, config)');
 
-    this.storage = new store(path.join(os.homedir(), ".homebridge") + '/.uix-rituals-secrets_' + this.hub);
-    this.user = path.join(os.homedir(), ".homebridge") + '/.uix-rituals-secrets_' + this.hub;
-    this.log.debug('RitualsAccesory -> storage path is :: ' + this.user);
+  this.storage = new store(
+    path.join(os.homedir(), '.homebridge') + '/.uix-rituals-secrets_' + this.hub
+  );
+  this.user =
+    path.join(os.homedir(), '.homebridge') +
+    '/.uix-rituals-secrets_' +
+    this.hub;
+  this.log.debug('RitualsAccesory -> storage path is :: ' + this.user);
 
-    this.on_state;
-    this.fan_speed;
-    this.account = config.account;
-    this.password = config.password;
+  this.on_state;
+  this.fan_speed;
+  this.account = config.account;
+  this.password = config.password;
 
-    this.key = this.storage.get('key') || 0;
-    this.log.debug('RitualsAccesory -> key :: ' + this.key);
+  this.key = this.storage.get('key') || 0;
+  this.log.debug('RitualsAccesory -> key :: ' + this.key);
 
-    this.name = this.storage.get('name') || config.name || 'Genie';
-    this.log.debug('RitualsAccesory -> name :: ' + this.name);
+  this.name = this.storage.get('name') || config.name || 'Genie';
+  this.log.debug('RitualsAccesory -> name :: ' + this.name);
 
-    this.hublot = this.storage.get('hublot') || 'SN_RND' + dt;
-    this.log.debug('RitualsAccesory -> hublot :: ' + this.hublot);
+  this.hublot = this.storage.get('hublot') || 'SN_RND' + dt;
+  this.log.debug('RitualsAccesory -> hublot :: ' + this.hublot);
 
-    this.version = this.storage.get('version') || version;
-    this.log.debug('RitualsAccesory -> version :: ' + this.version);
+  this.version = this.storage.get('version') || version;
+  this.log.debug('RitualsAccesory -> version :: ' + this.version);
 
-    this.fragance = this.storage.get('fragance') || 'N/A';
-    this.log.debug('RitualsAccesory -> fragance :: ' + this.fragance);
+  this.fragance = this.storage.get('fragance') || 'N/A';
+  this.log.debug('RitualsAccesory -> fragance :: ' + this.fragance);
 
-    var determinate_model = this.version.split('.');
-    if (determinate_model[determinate_model.length - 1] < 12) {
-        this.model_version = '1.0';
-    } else {
-        this.model_version = '2.0';
-    }
+  var determinate_model = this.version.split('.');
+  if (determinate_model[determinate_model.length - 1] < 12) {
+    this.model_version = '1.0';
+  } else {
+    this.model_version = '2.0';
+  }
 
-    this.service = new Service.Fan(this.name, 'AirFresher');
-    this.service
-        .getCharacteristic(Characteristic.On)
-        .on('get', this.getCurrentState.bind(this))
-        .on('set', this.setActiveState.bind(this));
+  this.service = new Service.Fan(this.name, 'AirFresher');
+  this.service
+    .getCharacteristic(Characteristic.On)
+    .on('get', this.getCurrentState.bind(this))
+    .on('set', this.setActiveState.bind(this));
 
-    this.service
-        .getCharacteristic(Characteristic.RotationSpeed)
-        .setProps({
-            minValue: 1,
-            maxValue: 3
-        })
-        .on('get', callback => callback(null, this.fan_speed))
-        .on('set', this.setFanSpeed.bind(this));
+  this.service
+    .getCharacteristic(Characteristic.RotationSpeed)
+    .setProps({
+      minValue: 1,
+      maxValue: 3,
+    })
+    .on('get', (callback) => callback(null, this.fan_speed))
+    .on('set', this.setFanSpeed.bind(this));
 
-    this.serviceInfo = new Service.AccessoryInformation();
-    this.serviceInfo
-        .setCharacteristic(Characteristic.Manufacturer, author)
-        .setCharacteristic(Characteristic.Model, 'Rituals Genie ' + this.model_version)
-        .setCharacteristic(Characteristic.SerialNumber, this.hublot)
-        .setCharacteristic(Characteristic.FirmwareRevision, this.version)
+  this.serviceInfo = new Service.AccessoryInformation();
+  this.serviceInfo
+    .setCharacteristic(Characteristic.Manufacturer, author)
+    .setCharacteristic(
+      Characteristic.Model,
+      'Rituals Genie ' + this.model_version
+    )
+    .setCharacteristic(Characteristic.SerialNumber, this.hublot)
+    .setCharacteristic(Characteristic.FirmwareRevision, this.version);
 
-    if (this.model_version == 1.0) {
-        this.serviceBatt = new Service.BatteryService('Battery', 'AirFresher');
-        this.serviceBatt
-            .setCharacteristic(Characteristic.BatteryLevel, '100')
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.CHARGING)
-            .setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
-            .setCharacteristic(Characteristic.Name, 'Genie Battery');
-    }
+  if (this.model_version == 1.0) {
+    this.serviceBatt = new Service.BatteryService('Battery', 'AirFresher');
+    this.serviceBatt
+      .setCharacteristic(Characteristic.BatteryLevel, '100')
+      .setCharacteristic(
+        Characteristic.ChargingState,
+        Characteristic.ChargingState.CHARGING
+      )
+      .setCharacteristic(
+        Characteristic.StatusLowBattery,
+        Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL
+      )
+      .setCharacteristic(Characteristic.Name, 'Genie Battery');
+  }
 
-    this.serviceFilter = new Service.FilterMaintenance('Filter', 'AirFresher');
-    this.serviceFilter
-        .setCharacteristic(Characteristic.FilterChangeIndication, Characteristic.FilterChangeIndication.FILTER_OK)
-        .setCharacteristic(Characteristic.Name, this.fragance);
+  this.serviceFilter = new Service.FilterMaintenance('Filter', 'AirFresher');
+  this.serviceFilter
+    .setCharacteristic(
+      Characteristic.FilterChangeIndication,
+      Characteristic.FilterChangeIndication.FILTER_OK
+    )
+    .setCharacteristic(Characteristic.Name, this.fragance);
 
-    //ChargingState.NOT_CHARGING (0)
-    //ChargingState.CHARGING (1)
-    //ChargingState.NOT_CHARGAEABLE (2)
-    //StatusLowBattery.BATTERY_LEVEL_NORMAL (0)
-    //StatusLowBattery.BATTERY_LEVEL_LOW (1)
+  //ChargingState.NOT_CHARGING (0)
+  //ChargingState.CHARGING (1)
+  //ChargingState.NOT_CHARGAEABLE (2)
+  //StatusLowBattery.BATTERY_LEVEL_NORMAL (0)
+  //StatusLowBattery.BATTERY_LEVEL_LOW (1)
 
-    this.services.push(this.service);
-    this.services.push(this.serviceInfo);
-    this.services.push(this.serviceBatt);
-    this.services.push(this.serviceFilter);
-    this.discover();
+  this.services.push(this.service);
+  this.services.push(this.serviceInfo);
+  this.services.push(this.serviceBatt);
+  this.services.push(this.serviceFilter);
+  this.discover();
 
-    this.log.debug('RitualsAccesory -> finish :: RitualsAccessory(log, config)');
+  this.log.debug('RitualsAccesory -> finish :: RitualsAccessory(log, config)');
 }
 
 RitualsAccessory.prototype = {
-
-    discover: function() {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: discover: function ()');
-        this.log.debug('RitualsAccesory -> package :: ' + version);
-        this.storage.put('hub', this.hub);
-        var hash = this.storage.get('hash') || null;
-        var hb = this.storage.get('hub') || null;
-        if (hash) {
-            this.log.debug('RitualsAccesory -> hash found in local storage');
-            this.log.debug('RitualsAccesory -> HASH :: ' + hash);
-            if (hb){
-            this.log.debug('RitualsAccesory -> hub found in local storage');
+  discover: function () {
+    const that = this;
+    this.log.debug('RitualsAccesory -> init :: discover: function ()');
+    this.log.debug('RitualsAccesory -> package :: ' + version);
+    this.storage.put('hub', this.hub);
+    var hash = this.storage.get('hash') || null;
+    var hb = this.storage.get('hub') || null;
+    if (hash) {
+      this.log.debug('RitualsAccesory -> hash found in local storage');
+      this.log.debug('RitualsAccesory -> HASH :: ' + hash);
+      if (hb) {
+        this.log.debug('RitualsAccesory -> hub found in local storage');
         this.log.debug('RitualsAccesory -> HUB :: ' + hb);
-            }else{
-              this.getHub();
-            } 
-        } else {
-            this.getHash();
-        }
-        this.log.debug('RitualsAccesory -> finish :: discover: function ()');
-    },
-
-    getHash: function() {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: getHash: function()');
-        var client = reqson.createClient('https://rituals.sense-company.com/');
-        var data = { email: this.account, password: this.password };
-        client.post('ocapi/login', data, function(err, res, body) {
-            if (err) { that.log.info(that.name + ' :: ERROR :: ocapi/login :: getHash() > ' + err) }
-            if (!err && res.statusCode != 200) {
-                that.log.debug('RitualsAccesory -> ajax :: ocapi/login -> INVALID STATUS CODE :: ' + res.statusCode);
-            } else {
-                that.log.debug('RitualsAccesory -> ajax :: ocapi/login :: OK ' + res.statusCode);
-                that.log.debug('RitualsAccesory -> ajax :: ocapi/login :: RESPONSE :: ' + body);
-                that.storage.put('hash', body.account_hash);
-                that.log.debug('RitualsAccesory -> ajax :: ocapi/login :: Setting hash in storage :: ' + body.account_hash);
-                that.getHub();
-            }
-        });
-        this.log.debug('RitualsAccesory -> finish :: getHash: function()');
-    },
-
-    getHub: function() {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: getHub: function()');
-        var client = reqson.createClient('https://rituals.sense-company.com/');
-        client.get('api/account/hubs/' + that.storage.get('hash'), function(err, res, body) {
-            if (err) { 
-              that.log.info(that.name + ' :: ERROR :: api/account/hubs :: getHub() > ' + err);
-              that.log.info('That means GENIE servers are down!');  
-          }else{
-              if (!err && res.statusCode != 200) {
-                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ -> INVALID STATUS CODE :: ' + res.statusCode);
-              } else {
-                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ OK :: ' + res.statusCode);
-                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ BODY.LENGTH :: ' + body.length + ' Genie in your account');
-                  if (body.length == 1) {
-                      that.key = 0;
-                      that.name = body[that.key].hub.attributes.roomnamec;
-                      that.hublot = body[that.key].hub.hublot;
-                      that.hub = body[that.key].hub.hash;
-                      that.storage.put('key', that.key);
-                      that.storage.put('name', body[that.key].hub.attributes.roomnamec);
-                      that.storage.put('hublot', body[that.key].hub.hublot);
-                      that.storage.put('hub', body[that.key].hub.hash);
-                      that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
-                      that.log.debug('RitualsAccesory -> hub 1 genie updated');
-                  } else {
-                      var found = false;
-                      Object.keys(body).forEach(function(key) {
-                          if (body[key].hub.hash == that.hub) {
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB declared in config VALIDATED OK ');
-                              found = true;
-                              that.key = key;
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Key is :: ' + key);
-                              that.name = body[key].hub.attributes.roomnamec;
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Name :: ' + body[key].hub.attributes.roomnamec);
-                              that.hublot = body[key].hub.hublot;
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Hublot :: ' + body[key].hub.hublot);
-                              that.fragance = body[that.key].hub.sensors.rfidc.title;
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: SENSORS Fragance :: ' + body[that.key].hub.sensors.rfidc.title);
-                              that.storage.put('key', key);
-                              that.storage.put('name', body[key].hub.attributes.roomnamec);
-                              that.storage.put('hublot', body[key].hub.hublot);
-                              that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
-                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: Saved HUB preferences in Storage');
-                          }
-                      });
-                      if (!found) {
-                          that.log.info("************************************************");
-                          that.log.info('HUB in Config NOT validated! or NOT in Config');
-                          that.log.info('please declare a correct section in config.json');
-                          that.log.info("************************************************");
-                          that.log.info('There are multiple Genies found on your account');
-                          that.log.info('The HUB Key to identify Genie in your config.json is invalid, select the proper HUB key.')
-                          that.log.info('Put one of the following your config.json > https://github.com/myluna08/homebridge-rituals');
-                          Object.keys(body).forEach(function(key) {
-                              that.log.info('********************');
-                              that.log.info('Name   : ' + body[key].hub.attributes.roomnamec);
-                              that.log.info('Hublot : ' + body[key].hub.hublot);
-                              that.log.info('Hub    : ' + body[key].hub.hash);
-                              that.log.info('Key    : ' + key);
-                          });
-                          that.log.info("************************************************");
-                      }
-                  }
-              }
-          }
-        });
-        this.log.debug('RitualsAccesory -> finish :: getHub: function()');
-    },
-
-    getCurrentState: function(callback) {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: getCurrentState: function(callback)');
-        var client = reqson.createClient('https://rituals.sense-company.com/');
-        client.get('api/account/hubs/' + that.storage.get('hash'), function(err, res, body) {
-            if (err) { that.log.info(that.name + ' :: ERROR :: api/account/hubs :: getCurrentState() > ' + err) }
-            if (!err && res.statusCode != 200) {
-                that.log.debug('RitualsAccesory -> ajax :: getCurrentState :: api/account/hubs/ -> INVALID STATUS CODE :: ' + res.statusCode);
-                that.log.info(that.name + ' getCurrentState => ' + res.statusCode + ' :: ' + err);
-            } else {
-                that.log.debug('RitualsAccesory -> ajax :: getCurrentState :: api/account/hubs/ OK :: ' + res.statusCode);
-                that.key = that.storage.get('key');
-                that.on_state = body[that.key].hub.attributes.fanc == '0' ? false : true;
-                that.fan_speed = body[that.key].hub.attributes.sppedc;
-                that.storage.put('version', body[that.key].hub.sensors.versionc);
-                callback(null, that.on_state);
-            }
-        });
-        this.log.debug('RitualsAccesory -> finish :: getCurrentState: function(callback)');
-    },
-
-    setActiveState: function(active, callback) {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: setActiveState: function(active, callback)');
-        this.log.debug('RitualsAccesory ->  setActiveState to ' + active);
-        this.log.info(that.name + ' :: Set ActiveState to => ' + active);
-        var setValue = active == true ? '1' : '0';
-        var client = reqson.createClient('https://rituals.sense-company.com/');
-        var data = { hub: that.hub, json: { attr: {  fanc: setValue } } };
-        client.post('api/hub/update/attr', data, function(err, res, body) {
-            if (err) {
-                that.log.info(that.name + ' :: ERROR :: api/account/hubs :: setActiveState() > ' + err);
-                callback(undefined, that.on_state);
-            }
-            if (!err && res.statusCode != 200) {
-                that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ -> INVALID STATUS CODE :: ' + res.statusCode);
-                that.log.info(that.name + ' :: setActiveState => ' + res.statusCode + ' :: ' + err);
-                callback(undefined, that.on_state);
-            } else {
-                that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ OK :: ' + res.statusCode);
-                that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ BODY :: ' + body);
-                callback(undefined, active);
-            }
-        });
-        this.log.debug('RitualsAccesory -> finish :: setActiveState: function(active, callback)');
-    },
-
-    setFanSpeed: function(value, callback) {
-        const that = this;
-        this.log.debug('RitualsAccesory -> init :: setFanSpeed: function(value, callback)');
-        this.log.info(that.name + ' :: Set FanSpeed to => ' + value);
-        var client = reqson.createClient('https://rituals.sense-company.com/');
-        var data = { hub: that.hub, json: { attr: {  speedc: value.toString() } } };
-        client.post('api/hub/update/attr', data, function(err, res, body) {
-            if (err) {
-                that.log.info(that.name + ' :: ERROR :: api/account/hubs :: setFanSpeed() > ' + err);
-                callback(undefined, fan_speed);
-            }
-            if (!err && res.statusCode != 200) {
-                that.log.debug('RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ -> INVALID STATUS CODE :: ' + res.statusCode);
-                that.log.info(that.name + ' :: setFanSpeed => ' + res.statusCode + ' :: ' + err);
-                callback(undefined, that.fan_speed);
-            } else {
-                that.log.debug('RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ OK :: ' + res.statusCode);
-                that.log.debug('RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ BODY :: ' + body);
-                callback(undefined, value);
-            }
-        });
-        this.log.debug('RitualsAccesory -> finish :: setFanSpeed: function(value, callback)');
-    },
-
-    identify: function(callback) {
-        callback();
-    },
-
-    getServices: function() {
-        return this.services;
+      } else {
+        this.getHub();
+      }
+    } else {
+      this.getHash();
     }
+    this.log.debug('RitualsAccesory -> finish :: discover: function ()');
+  },
+
+  getHash: function () {
+    const that = this;
+    this.log.debug('RitualsAccesory -> init :: getHash: function()');
+    var client = reqson.createClient('https://rituals.sense-company.com/');
+    var data = { email: this.account, password: this.password };
+    client.post('ocapi/login', data, function (err, res, body) {
+      if (err) {
+        that.log.info(
+          that.name + ' :: ERROR :: ocapi/login :: getHash() > ' + err
+        );
+      }
+      if (!err && res.statusCode != 200) {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: ocapi/login -> INVALID STATUS CODE :: ' +
+            res.statusCode
+        );
+      } else {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: ocapi/login :: OK ' + res.statusCode
+        );
+        that.log.debug(
+          'RitualsAccesory -> ajax :: ocapi/login :: RESPONSE :: ' + body
+        );
+        that.storage.put('hash', body.account_hash);
+        that.log.debug(
+          'RitualsAccesory -> ajax :: ocapi/login :: Setting hash in storage :: ' +
+            body.account_hash
+        );
+        that.getHub();
+      }
+    });
+    this.log.debug('RitualsAccesory -> finish :: getHash: function()');
+  },
+
+  getHub: function () {
+    const that = this;
+    this.log.debug('RitualsAccesory -> init :: getHub: function()');
+    var client = reqson.createClient('https://rituals.sense-company.com/');
+    client.get('api/account/hubs/' + that.storage.get('hash'), function (
+      err,
+      res,
+      body
+    ) {
+      if (err) {
+        that.log.info(
+          that.name + ' :: ERROR :: api/account/hubs :: getHub() > ' + err
+        );
+        that.log.info('That means GENIE servers are down!');
+      } else {
+        if (!err && res.statusCode != 200) {
+          that.log.debug(
+            'RitualsAccesory -> ajax :: api/account/hubs/ -> INVALID STATUS CODE :: ' +
+              res.statusCode
+          );
+        } else {
+          that.log.debug(
+            'RitualsAccesory -> ajax :: api/account/hubs/ OK :: ' +
+              res.statusCode
+          );
+          that.log.debug(
+            'RitualsAccesory -> ajax :: api/account/hubs/ BODY.LENGTH :: ' +
+              body.length +
+              ' Genie in your account'
+          );
+          if (body.length == 1) {
+            that.key = 0;
+            that.name = body[that.key].hub.attributes.roomnamec;
+            that.hublot = body[that.key].hub.hublot;
+            that.hub = body[that.key].hub.hash;
+            that.storage.put('key', that.key);
+            that.storage.put('name', body[that.key].hub.attributes.roomnamec);
+            that.storage.put('hublot', body[that.key].hub.hublot);
+            that.storage.put('hub', body[that.key].hub.hash);
+            that.storage.put(
+              'fragance',
+              body[that.key].hub.sensors.rfidc.title
+            );
+            that.log.debug('RitualsAccesory -> hub 1 genie updated');
+          } else {
+            var found = false;
+            Object.keys(body).forEach(function (key) {
+              if (body[key].hub.hash == that.hub) {
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: HUB declared in config VALIDATED OK '
+                );
+                found = true;
+                that.key = key;
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Key is :: ' +
+                    key
+                );
+                that.name = body[key].hub.attributes.roomnamec;
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Name :: ' +
+                    body[key].hub.attributes.roomnamec
+                );
+                that.hublot = body[key].hub.hublot;
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Hublot :: ' +
+                    body[key].hub.hublot
+                );
+                that.fragance = body[that.key].hub.sensors.rfidc.title;
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: SENSORS Fragance :: ' +
+                    body[that.key].hub.sensors.rfidc.title
+                );
+                that.storage.put('key', key);
+                that.storage.put('name', body[key].hub.attributes.roomnamec);
+                that.storage.put('hublot', body[key].hub.hublot);
+                that.storage.put(
+                  'fragance',
+                  body[that.key].hub.sensors.rfidc.title
+                );
+                that.log.debug(
+                  'RitualsAccesory -> ajax :: api/account/hubs/ :: Saved HUB preferences in Storage'
+                );
+              }
+            });
+            if (!found) {
+              that.log.info('************************************************');
+              that.log.info('HUB in Config NOT validated! or NOT in Config');
+              that.log.info('please declare a correct section in config.json');
+              that.log.info('************************************************');
+              that.log.info('There are multiple Genies found on your account');
+              that.log.info(
+                'The HUB Key to identify Genie in your config.json is invalid, select the proper HUB key.'
+              );
+              that.log.info(
+                'Put one of the following your config.json > https://github.com/myluna08/homebridge-rituals'
+              );
+              Object.keys(body).forEach(function (key) {
+                that.log.info('********************');
+                that.log.info('Name   : ' + body[key].hub.attributes.roomnamec);
+                that.log.info('Hublot : ' + body[key].hub.hublot);
+                that.log.info('Hub    : ' + body[key].hub.hash);
+                that.log.info('Key    : ' + key);
+              });
+              that.log.info('************************************************');
+            }
+          }
+        }
+      }
+    });
+    this.log.debug('RitualsAccesory -> finish :: getHub: function()');
+  },
+
+  getCurrentState: function (callback) {
+    const that = this;
+    this.log.debug(
+      'RitualsAccesory -> init :: getCurrentState: function(callback)'
+    );
+    var client = reqson.createClient('https://rituals.sense-company.com/');
+    client.get('api/account/hubs/' + that.storage.get('hash'), function (
+      err,
+      res,
+      body
+    ) {
+      if (err) {
+        that.log.info(
+          that.name +
+            ' :: ERROR :: api/account/hubs :: getCurrentState() > ' +
+            err
+        );
+      }
+      if (!err && res.statusCode != 200) {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: getCurrentState :: api/account/hubs/ -> INVALID STATUS CODE :: ' +
+            res.statusCode
+        );
+        that.log.info(
+          that.name + ' getCurrentState => ' + res.statusCode + ' :: ' + err
+        );
+      } else {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: getCurrentState :: api/account/hubs/ OK :: ' +
+            res.statusCode
+        );
+        that.key = that.storage.get('key');
+        that.on_state =
+          body[that.key].hub.attributes.fanc == '0' ? false : true;
+        that.fan_speed = body[that.key].hub.attributes.sppedc;
+        that.storage.put('version', body[that.key].hub.sensors.versionc);
+        callback(null, that.on_state);
+      }
+    });
+    this.log.debug(
+      'RitualsAccesory -> finish :: getCurrentState: function(callback)'
+    );
+  },
+
+  setActiveState: function (active, callback) {
+    const that = this;
+    this.log.debug(
+      'RitualsAccesory -> init :: setActiveState: function(active, callback)'
+    );
+    this.log.debug('RitualsAccesory ->  setActiveState to ' + active);
+    this.log.info(that.name + ' :: Set ActiveState to => ' + active);
+    var setValue = active == true ? '1' : '0';
+    var client = reqson.createClient('https://rituals.sense-company.com/');
+    var data = { hub: that.hub, json: { attr: { fanc: setValue } } };
+    client.post('api/hub/update/attr', data, function (err, res, body) {
+      if (err) {
+        that.log.info(
+          that.name +
+            ' :: ERROR :: api/account/hubs :: setActiveState() > ' +
+            err
+        );
+        callback(undefined, that.on_state);
+      }
+      if (!err && res.statusCode != 200) {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ -> INVALID STATUS CODE :: ' +
+            res.statusCode
+        );
+        that.log.info(
+          that.name + ' :: setActiveState => ' + res.statusCode + ' :: ' + err
+        );
+        callback(undefined, that.on_state);
+      } else {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ OK :: ' +
+            res.statusCode
+        );
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ BODY :: ' +
+            body
+        );
+        callback(undefined, active);
+      }
+    });
+    this.log.debug(
+      'RitualsAccesory -> finish :: setActiveState: function(active, callback)'
+    );
+  },
+
+  setFanSpeed: function (value, callback) {
+    const that = this;
+    this.log.debug(
+      'RitualsAccesory -> init :: setFanSpeed: function(value, callback)'
+    );
+    this.log.info(that.name + ' :: Set FanSpeed to => ' + value);
+    var client = reqson.createClient('https://rituals.sense-company.com/');
+    var data = { hub: that.hub, json: { attr: { speedc: value.toString() } } };
+    client.post('api/hub/update/attr', data, function (err, res, body) {
+      if (err) {
+        that.log.info(
+          that.name + ' :: ERROR :: api/account/hubs :: setFanSpeed() > ' + err
+        );
+        callback(undefined, fan_speed);
+      }
+      if (!err && res.statusCode != 200) {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ -> INVALID STATUS CODE :: ' +
+            res.statusCode
+        );
+        that.log.info(
+          that.name + ' :: setFanSpeed => ' + res.statusCode + ' :: ' + err
+        );
+        callback(undefined, that.fan_speed);
+      } else {
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ OK :: ' +
+            res.statusCode
+        );
+        that.log.debug(
+          'RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ BODY :: ' +
+            body
+        );
+        callback(undefined, value);
+      }
+    });
+    this.log.debug(
+      'RitualsAccesory -> finish :: setFanSpeed: function(value, callback)'
+    );
+  },
+
+  identify: function (callback) {
+    callback();
+  },
+
+  getServices: function () {
+    return this.services;
+  },
 };

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ RitualsAccessory.prototype = {
                 that.storage.put('hash', body.account_hash);
                 that.log.debug('RitualsAccesory -> ajax :: ocapi/login :: Setting hash in storage :: ' + body.account_hash);
                 that.getHub();
-            };
+            }
         });
         this.log.debug('RitualsAccesory -> finish :: getHash: function()');
     },
@@ -241,7 +241,7 @@ RitualsAccessory.prototype = {
                 that.fan_speed = body[that.key].hub.attributes.sppedc;
                 that.storage.put('version', body[that.key].hub.sensors.versionc);
                 callback(null, that.on_state);
-            };
+            }
         });
         this.log.debug('RitualsAccesory -> finish :: getCurrentState: function(callback)');
     },
@@ -267,7 +267,7 @@ RitualsAccessory.prototype = {
                 that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ OK :: ' + res.statusCode);
                 that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ BODY :: ' + body);
                 callback(undefined, active);
-            };
+            }
         });
         this.log.debug('RitualsAccesory -> finish :: setActiveState: function(active, callback)');
     },
@@ -291,7 +291,7 @@ RitualsAccessory.prototype = {
                 that.log.debug('RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ OK :: ' + res.statusCode);
                 that.log.debug('RitualsAccesory -> ajax :: setFanSpeed :: api/hub/update/attr/ BODY :: ' + body);
                 callback(undefined, value);
-            };
+            }
         });
         this.log.debug('RitualsAccesory -> finish :: setFanSpeed: function(value, callback)');
     },

--- a/index.js
+++ b/index.js
@@ -7,12 +7,9 @@ const reqson = require('request-json');
 
 const version = require('./package.json').version;
 const author = require('./package.json').author.name;
-const _where = require('./package.json')._where;
-const _loc = require('./package.json')._location;
 
 let Service;
 let Characteristic;
-let logger;
 
 module.exports = function (homebridge) {
   Service = homebridge.hap.Service;
@@ -134,7 +131,6 @@ function RitualsAccessory(log, config) {
 
 RitualsAccessory.prototype = {
   discover: function () {
-    const that = this;
     this.log.debug('RitualsAccesory -> init :: discover: function ()');
     this.log.debug('RitualsAccesory -> package :: ' + version);
     this.storage.put('hub', this.hub);
@@ -403,7 +399,7 @@ RitualsAccessory.prototype = {
         that.log.info(
           that.name + ' :: ERROR :: api/account/hubs :: setFanSpeed() > ' + err
         );
-        callback(undefined, fan_speed);
+        callback(undefined, that.fan_speed);
       }
       if (!err && res.statusCode != 200) {
         that.log.debug(

--- a/index.js
+++ b/index.js
@@ -124,10 +124,10 @@ RitualsAccessory.prototype = {
             this.log.debug('RitualsAccesory -> hash found in local storage');
             this.log.debug('RitualsAccesory -> HASH :: ' + hash);
             if (hb){
-	        	this.log.debug('RitualsAccesory -> hub found in local storage');
-				this.log.debug('RitualsAccesory -> HUB :: ' + hb);
+            this.log.debug('RitualsAccesory -> hub found in local storage');
+        this.log.debug('RitualsAccesory -> HUB :: ' + hb);
             }else{
-            	this.getHub();
+              this.getHub();
             } 
         } else {
             this.getHash();
@@ -161,66 +161,66 @@ RitualsAccessory.prototype = {
         var client = reqson.createClient('https://rituals.sense-company.com/');
         client.get('api/account/hubs/' + that.storage.get('hash'), function(err, res, body) {
             if (err) { 
-	            that.log.info(that.name + ' :: ERROR :: api/account/hubs :: getHub() > ' + err);
-	            that.log.info('That means GENIE servers are down!');  
-	        }else{
-	            if (!err && res.statusCode != 200) {
-	                that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ -> INVALID STATUS CODE :: ' + res.statusCode);
-	            } else {
-	                that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ OK :: ' + res.statusCode);
-	                that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ BODY.LENGTH :: ' + body.length + ' Genie in your account');
-	                if (body.length == 1) {
-	                    that.key = 0;
-	                    that.name = body[that.key].hub.attributes.roomnamec;
-	                    that.hublot = body[that.key].hub.hublot;
-	                    that.hub = body[that.key].hub.hash;
-	                    that.storage.put('key', that.key);
-	                    that.storage.put('name', body[that.key].hub.attributes.roomnamec);
-	                    that.storage.put('hublot', body[that.key].hub.hublot);
-	                    that.storage.put('hub', body[that.key].hub.hash);
-	                    that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
-	                    that.log.debug('RitualsAccesory -> hub 1 genie updated');
-	                } else {
-	                    var found = false;
-	                    Object.keys(body).forEach(function(key) {
-	                        if (body[key].hub.hash == that.hub) {
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB declared in config VALIDATED OK ');
-	                            found = true;
-	                            that.key = key;
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Key is :: ' + key);
-	                            that.name = body[key].hub.attributes.roomnamec;
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Name :: ' + body[key].hub.attributes.roomnamec);
-	                            that.hublot = body[key].hub.hublot;
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Hublot :: ' + body[key].hub.hublot);
-	                            that.fragance = body[that.key].hub.sensors.rfidc.title;
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: SENSORS Fragance :: ' + body[that.key].hub.sensors.rfidc.title);
-	                            that.storage.put('key', key);
-	                            that.storage.put('name', body[key].hub.attributes.roomnamec);
-	                            that.storage.put('hublot', body[key].hub.hublot);
-	                            that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
-	                            that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: Saved HUB preferences in Storage');
-	                        }
-	                    });
-	                    if (!found) {
-	                        that.log.info("************************************************");
-	                        that.log.info('HUB in Config NOT validated! or NOT in Config');
-	                        that.log.info('please declare a correct section in config.json');
-	                        that.log.info("************************************************");
-	                        that.log.info('There are multiple Genies found on your account');
-	                        that.log.info('The HUB Key to identify Genie in your config.json is invalid, select the proper HUB key.')
-	                        that.log.info('Put one of the following your config.json > https://github.com/myluna08/homebridge-rituals');
-	                        Object.keys(body).forEach(function(key) {
-	                            that.log.info('********************');
-	                            that.log.info('Name   : ' + body[key].hub.attributes.roomnamec);
-	                            that.log.info('Hublot : ' + body[key].hub.hublot);
-	                            that.log.info('Hub    : ' + body[key].hub.hash);
-	                            that.log.info('Key    : ' + key);
-	                        });
-	                        that.log.info("************************************************");
-	                    }
-	                }
-	            }
-	        }
+              that.log.info(that.name + ' :: ERROR :: api/account/hubs :: getHub() > ' + err);
+              that.log.info('That means GENIE servers are down!');  
+          }else{
+              if (!err && res.statusCode != 200) {
+                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ -> INVALID STATUS CODE :: ' + res.statusCode);
+              } else {
+                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ OK :: ' + res.statusCode);
+                  that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ BODY.LENGTH :: ' + body.length + ' Genie in your account');
+                  if (body.length == 1) {
+                      that.key = 0;
+                      that.name = body[that.key].hub.attributes.roomnamec;
+                      that.hublot = body[that.key].hub.hublot;
+                      that.hub = body[that.key].hub.hash;
+                      that.storage.put('key', that.key);
+                      that.storage.put('name', body[that.key].hub.attributes.roomnamec);
+                      that.storage.put('hublot', body[that.key].hub.hublot);
+                      that.storage.put('hub', body[that.key].hub.hash);
+                      that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
+                      that.log.debug('RitualsAccesory -> hub 1 genie updated');
+                  } else {
+                      var found = false;
+                      Object.keys(body).forEach(function(key) {
+                          if (body[key].hub.hash == that.hub) {
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB declared in config VALIDATED OK ');
+                              found = true;
+                              that.key = key;
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Key is :: ' + key);
+                              that.name = body[key].hub.attributes.roomnamec;
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Name :: ' + body[key].hub.attributes.roomnamec);
+                              that.hublot = body[key].hub.hublot;
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: HUB Hublot :: ' + body[key].hub.hublot);
+                              that.fragance = body[that.key].hub.sensors.rfidc.title;
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: SENSORS Fragance :: ' + body[that.key].hub.sensors.rfidc.title);
+                              that.storage.put('key', key);
+                              that.storage.put('name', body[key].hub.attributes.roomnamec);
+                              that.storage.put('hublot', body[key].hub.hublot);
+                              that.storage.put('fragance', body[that.key].hub.sensors.rfidc.title);
+                              that.log.debug('RitualsAccesory -> ajax :: api/account/hubs/ :: Saved HUB preferences in Storage');
+                          }
+                      });
+                      if (!found) {
+                          that.log.info("************************************************");
+                          that.log.info('HUB in Config NOT validated! or NOT in Config');
+                          that.log.info('please declare a correct section in config.json');
+                          that.log.info("************************************************");
+                          that.log.info('There are multiple Genies found on your account');
+                          that.log.info('The HUB Key to identify Genie in your config.json is invalid, select the proper HUB key.')
+                          that.log.info('Put one of the following your config.json > https://github.com/myluna08/homebridge-rituals');
+                          Object.keys(body).forEach(function(key) {
+                              that.log.info('********************');
+                              that.log.info('Name   : ' + body[key].hub.attributes.roomnamec);
+                              that.log.info('Hublot : ' + body[key].hub.hublot);
+                              that.log.info('Hub    : ' + body[key].hub.hash);
+                              that.log.info('Key    : ' + key);
+                          });
+                          that.log.info("************************************************");
+                      }
+                  }
+              }
+          }
         });
         this.log.debug('RitualsAccesory -> finish :: getHub: function()');
     },

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ RitualsAccessory.prototype = {
         client.post('api/hub/update/attr', data, function(err, res, body) {
             if (err) {
                 that.log.info(that.name + ' :: ERROR :: api/account/hubs :: setActiveState() > ' + err);
-                callback(undefined, on_state);
+                callback(undefined, that.on_state);
             }
             if (!err && res.statusCode != 200) {
                 that.log.debug('RitualsAccesory -> ajax :: setActiveState :: api/hub/update/attr/ -> INVALID STATUS CODE :: ' + res.statusCode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1601 +1,1601 @@
 {
-    "name": "homebridge-rituals",
-    "version": "1.1.9",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "@babel/code-frame": {
-            "version": "7.10.4",
-            "resolved": "https://npm.buzzfeed.com/@babel/code-frame/-/code-frame-7.10.4/168da1a36e90da68ae8d49c0f1b48c7c6249213a.tgz",
-            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-            "dev": true,
-            "requires": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "@babel/helper-validator-identifier": {
-            "version": "7.10.4",
-            "resolved": "https://npm.buzzfeed.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4/a78c7a7251e01f616512d31b10adcf52ada5e0d2.tgz",
-            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-            "dev": true
-        },
-        "@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://npm.buzzfeed.com/@babel/highlight/-/highlight-7.10.4/7d1bdfd65753538fabe6c38596cdb76d9ac60143.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                }
-            }
-        },
-        "@eslint/eslintrc": {
-            "version": "0.1.3",
-            "resolved": "https://npm.buzzfeed.com/@eslint/eslintrc/-/eslintrc-0.1.3/7d1a2b2358552cc04834c0979bd4275362e37085.tgz",
-            "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.12.4",
-                "debug": "^4.1.1",
-                "espree": "^7.3.0",
-                "globals": "^12.1.0",
-                "ignore": "^4.0.6",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.19",
-                "minimatch": "^3.0.4",
-                "strip-json-comments": "^3.1.1"
-            }
-        },
-        "@types/eslint-visitor-keys": {
-            "version": "1.0.0",
-            "resolved": "https://npm.buzzfeed.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0/1ee30d79544ca84d68d4b3cdb0af4f205663dd2d.tgz",
-            "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-            "dev": true
-        },
-        "@types/json-schema": {
-            "version": "7.0.6",
-            "resolved": "https://npm.buzzfeed.com/@types/json-schema/-/json-schema-7.0.6/f4c7ec43e81b319a9815115031709f26987891f0.tgz",
-            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-            "dev": true
-        },
-        "@typescript-eslint/experimental-utils": {
-            "version": "3.10.1",
-            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1/e179ffc81a80ebcae2ea04e0332f8b251345a686.tgz",
-            "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/types": "3.10.1",
-                "@typescript-eslint/typescript-estree": "3.10.1",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "3.10.1",
-            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/parser/-/parser-3.10.1/1883858e83e8b442627e1ac6f408925211155467.tgz",
-            "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
-            "dev": true,
-            "requires": {
-                "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "3.10.1",
-                "@typescript-eslint/types": "3.10.1",
-                "@typescript-eslint/typescript-estree": "3.10.1",
-                "eslint-visitor-keys": "^1.1.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "3.10.1",
-            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/types/-/types-3.10.1/1d7463fa7c32d8a23ab508a803ca2fe26e758727.tgz",
-            "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "3.10.1",
-            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1/fd0061cc38add4fad45136d654408569f365b853.tgz",
-            "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "3.10.1",
-                "@typescript-eslint/visitor-keys": "3.10.1",
-                "debug": "^4.1.1",
-                "glob": "^7.1.6",
-                "is-glob": "^4.0.1",
-                "lodash": "^4.17.15",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "3.10.1",
-            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1/cd4274773e3eb63b2e870ac602274487ecd1e931.tgz",
-            "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^1.1.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
-            }
-        },
-        "acorn": {
-            "version": "7.4.1",
-            "resolved": "https://npm.buzzfeed.com/acorn/-/acorn-7.4.1/feaed255973d2e77555b83dbc08851a6c63520fa.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "dev": true
-        },
-        "acorn-jsx": {
-            "version": "5.3.1",
-            "resolved": "https://npm.buzzfeed.com/acorn-jsx/-/acorn-jsx-5.3.1/fc8661e11b7ac1539c47dbfea2e72b3af34d267b.tgz",
-            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://npm.buzzfeed.com/ajv/-/ajv-6.12.6/baf5a62e802b07d977034586f8c3baf5adf26df4.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
-        "ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://npm.buzzfeed.com/ansi-colors/-/ansi-colors-4.1.1/cbb9ae256bf750af1eab344f229aa27fe94ba348.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true
-        },
-        "ansi-escapes": {
-            "version": "4.3.1",
-            "resolved": "https://npm.buzzfeed.com/ansi-escapes/-/ansi-escapes-4.3.1/a5c47cc43181f1f38ffd7076837700d395522a61.tgz",
-            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.11.0"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.11.0",
-                    "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.11.0/97abf0872310fed88a5c466b25681576145e33f1.tgz",
-                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-                    "dev": true
-                }
-            }
-        },
-        "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-5.0.0/388539f55179bf39339c81af30a654d69f87cb75.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true
-        },
-        "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-3.2.1/41fbb20243e50b12be0f04b8dedbf07520ce841d.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^1.9.0"
-            }
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://npm.buzzfeed.com/argparse/-/argparse-1.0.10/bcd6791ea5ae09725e17e5ad988134cd40b3d911.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "astral-regex": {
-            "version": "1.0.0",
-            "resolved": "https://npm.buzzfeed.com/astral-regex/-/astral-regex-1.0.0/6c8c3fb827dd43ee3918f27b82782ab7658a6fd9.tgz",
-            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-            "dev": true
-        },
-        "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://npm.buzzfeed.com/balanced-match/-/balanced-match-1.0.0/89b4d199ab2bee49de164ea02b89ce462d71b767.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://npm.buzzfeed.com/brace-expansion/-/brace-expansion-1.1.11/3c7fcbf529d87226f3d2f52b966ff5271eb441dd.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "callsites": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/callsites/-/callsites-3.1.0/b3630abd8943432f54b3f0519238e33cd7df2f73.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
-        },
+  "name": "homebridge-rituals",
+  "version": "1.1.10",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://npm.buzzfeed.com/@babel/code-frame/-/code-frame-7.10.4/168da1a36e90da68ae8d49c0f1b48c7c6249213a.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://npm.buzzfeed.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4/a78c7a7251e01f616512d31b10adcf52ada5e0d2.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://npm.buzzfeed.com/@babel/highlight/-/highlight-7.10.4/7d1bdfd65753538fabe6c38596cdb76d9ac60143.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
         "chalk": {
-            "version": "4.1.0",
-            "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-4.1.0/4e14870a618d9e2edd97dd8345fd9d9dc315646a.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-4.3.0/edd803628ae71c04c85ae7a0906edad34b648937.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-2.0.1/72d3a68d598c9bdb3af2ad1e84f21d896abd4de3.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.4/c2a09a87acbde69543de6f63fa3995c826c536a2.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-4.0.0/944771fd9c81c81265c4d6941860da06bb59479b.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-7.2.0/1b7dcdcb32b8138801b3e478ba6a51caa89648da.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "chardet": {
-            "version": "0.7.0",
-            "resolved": "https://npm.buzzfeed.com/chardet/-/chardet-0.7.0/90094849f0937f2eedc2425d0d28a9e5f0cbad9e.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
-        "cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/cli-cursor/-/cli-cursor-3.1.0/264305a7ae490d1d03bf0c9ba7c925d1753af307.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "^3.1.0"
-            }
-        },
-        "cli-width": {
-            "version": "3.0.0",
-            "resolved": "https://npm.buzzfeed.com/cli-width/-/cli-width-3.0.0/a2f48437a2caa9a22436e794bf071ec9e61cedf6.tgz",
-            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-            "dev": true
+          "version": "2.4.2",
+          "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.1.3",
+      "resolved": "https://npm.buzzfeed.com/@eslint/eslintrc/-/eslintrc-0.1.3/7d1a2b2358552cc04834c0979bd4275362e37085.tgz",
+      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://npm.buzzfeed.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0/1ee30d79544ca84d68d4b3cdb0af4f205663dd2d.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://npm.buzzfeed.com/@types/json-schema/-/json-schema-7.0.6/f4c7ec43e81b319a9815115031709f26987891f0.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "3.10.1",
+      "resolved": "https://npm.buzzfeed.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1/e179ffc81a80ebcae2ea04e0332f8b251345a686.tgz",
+      "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "3.10.1",
+      "resolved": "https://npm.buzzfeed.com/@typescript-eslint/parser/-/parser-3.10.1/1883858e83e8b442627e1ac6f408925211155467.tgz",
+      "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "3.10.1",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://npm.buzzfeed.com/@typescript-eslint/types/-/types-3.10.1/1d7463fa7c32d8a23ab508a803ca2fe26e758727.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "3.10.1",
+      "resolved": "https://npm.buzzfeed.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1/fd0061cc38add4fad45136d654408569f365b853.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://npm.buzzfeed.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1/cd4274773e3eb63b2e870ac602274487ecd1e931.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://npm.buzzfeed.com/acorn/-/acorn-7.4.1/feaed255973d2e77555b83dbc08851a6c63520fa.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://npm.buzzfeed.com/acorn-jsx/-/acorn-jsx-5.3.1/fc8661e11b7ac1539c47dbfea2e72b3af34d267b.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://npm.buzzfeed.com/ajv/-/ajv-6.12.6/baf5a62e802b07d977034586f8c3baf5adf26df4.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://npm.buzzfeed.com/ansi-colors/-/ansi-colors-4.1.1/cbb9ae256bf750af1eab344f229aa27fe94ba348.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://npm.buzzfeed.com/ansi-escapes/-/ansi-escapes-4.3.1/a5c47cc43181f1f38ffd7076837700d395522a61.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.11.0/97abf0872310fed88a5c466b25681576145e33f1.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-5.0.0/388539f55179bf39339c81af30a654d69f87cb75.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-3.2.1/41fbb20243e50b12be0f04b8dedbf07520ce841d.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://npm.buzzfeed.com/argparse/-/argparse-1.0.10/bcd6791ea5ae09725e17e5ad988134cd40b3d911.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://npm.buzzfeed.com/astral-regex/-/astral-regex-1.0.0/6c8c3fb827dd43ee3918f27b82782ab7658a6fd9.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://npm.buzzfeed.com/balanced-match/-/balanced-match-1.0.0/89b4d199ab2bee49de164ea02b89ce462d71b767.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://npm.buzzfeed.com/brace-expansion/-/brace-expansion-1.1.11/3c7fcbf529d87226f3d2f52b966ff5271eb441dd.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/callsites/-/callsites-3.1.0/b3630abd8943432f54b3f0519238e33cd7df2f73.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-4.1.0/4e14870a618d9e2edd97dd8345fd9d9dc315646a.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-4.3.0/edd803628ae71c04c85ae7a0906edad34b648937.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-1.9.3/bb71850690e1f136567de629d2d5471deda4c1e8.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
+          "version": "2.0.1",
+          "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-2.0.1/72d3a68d598c9bdb3af2ad1e84f21d896abd4de3.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
         },
         "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.3/a7d0558bd89c42f795dd42328f740831ca53bc25.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "common-tags": {
-            "version": "1.8.0",
-            "resolved": "https://npm.buzzfeed.com/common-tags/-/common-tags-1.8.0/8e3153e542d4a39e9b10554434afaaf98956a937.tgz",
-            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-            "dev": true
-        },
-        "concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://npm.buzzfeed.com/concat-map/-/concat-map-0.0.1/d8a96bd77fd68df7793a73036a3ba0d5405d477b.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
-        },
-        "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-7.0.3/f73a85b9d5d41d045551c177e2882d4ac85728a6.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
-            "requires": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            }
-        },
-        "debug": {
-            "version": "4.2.0",
-            "resolved": "https://npm.buzzfeed.com/debug/-/debug-4.2.0/7f150f93920e94c58f5574c2fd01a3110effe7f1.tgz",
-            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-            "dev": true,
-            "requires": {
-                "ms": "2.1.2"
-            }
-        },
-        "deep-is": {
-            "version": "0.1.3",
-            "resolved": "https://npm.buzzfeed.com/deep-is/-/deep-is-0.1.3/b369d6fb5dbc13eecf524f91b070feedc357cf34.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
-        },
-        "dlv": {
-            "version": "1.1.3",
-            "resolved": "https://npm.buzzfeed.com/dlv/-/dlv-1.1.3/5c198a8a11453596e751494d49874bc7732f2e79.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true
-        },
-        "doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://npm.buzzfeed.com/doctrine/-/doctrine-3.0.0/addebead72a6574db783639dc87a121773973961.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "requires": {
-                "esutils": "^2.0.2"
-            }
-        },
-        "emoji-regex": {
-            "version": "7.0.3",
-            "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-7.0.3/933a04052860c85e83c122479c4748a8e4c72156.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-            "dev": true
-        },
-        "enquirer": {
-            "version": "2.3.6",
-            "resolved": "https://npm.buzzfeed.com/enquirer/-/enquirer-2.3.6/2a7fe5dd634a1e4125a975ec994ff5456dc3734d.tgz",
-            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "^4.1.1"
-            }
-        },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://npm.buzzfeed.com/escape-string-regexp/-/escape-string-regexp-1.0.5/1b61c0562190a8dff6ae3bb2cf0200ca130b86d4.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "eslint": {
-            "version": "7.11.0",
-            "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-7.11.0/aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b.tgz",
-            "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@eslint/eslintrc": "^0.1.3",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.0.1",
-                "doctrine": "^3.0.0",
-                "enquirer": "^2.3.5",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^2.1.0",
-                "eslint-visitor-keys": "^2.0.0",
-                "espree": "^7.3.0",
-                "esquery": "^1.2.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^5.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
-                "ignore": "^4.0.6",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^3.13.1",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash": "^4.17.19",
-                "minimatch": "^3.0.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "progress": "^2.0.0",
-                "regexpp": "^3.1.0",
-                "semver": "^7.2.1",
-                "strip-ansi": "^6.0.0",
-                "strip-json-comments": "^3.1.0",
-                "table": "^5.2.3",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-            }
-        },
-        "eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://npm.buzzfeed.com/eslint-scope/-/eslint-scope-5.1.1/e786e59a66cb92b3f6c1fb0d508aab174848f48c.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            }
-        },
-        "eslint-utils": {
-            "version": "2.1.0",
-            "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-2.1.0/d2de5e03424e707dc10c74068ddedae708741b27.tgz",
-            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^1.1.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "2.0.0",
-            "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0/21fdc8fbcd9c795cc0321f0563702095751511a8.tgz",
-            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
-            "dev": true
-        },
-        "espree": {
-            "version": "7.3.0",
-            "resolved": "https://npm.buzzfeed.com/espree/-/espree-7.3.0/dc30437cf67947cf576121ebd780f15eeac72348.tgz",
-            "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
-            "dev": true,
-            "requires": {
-                "acorn": "^7.4.0",
-                "acorn-jsx": "^5.2.0",
-                "eslint-visitor-keys": "^1.3.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
-            }
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://npm.buzzfeed.com/esprima/-/esprima-4.0.1/13b04cdb3e6c5d19df91ab6987a8695619b0aa71.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "esquery": {
-            "version": "1.3.1",
-            "resolved": "https://npm.buzzfeed.com/esquery/-/esquery-1.3.1/b78b5828aa8e214e29fb74c4d5b752e1c033da57.tgz",
-            "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.1.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-                    "dev": true
-                }
-            }
-        },
-        "esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://npm.buzzfeed.com/esrecurse/-/esrecurse-4.3.0/7ad7964d679abb28bee72cec63758b1c5d2c9921.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-                    "dev": true
-                }
-            }
-        },
-        "estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-4.3.0/398ad3f3c5a24948be7725e83d11a7de28cdbd1d.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://npm.buzzfeed.com/esutils/-/esutils-2.0.3/74d2eb4de0b8da1293711910d50775b9b710ef64.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
-        "external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/external-editor/-/external-editor-3.1.0/cb03f740befae03ea4d283caed2741a83f335495.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            }
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://npm.buzzfeed.com/fast-deep-equal/-/fast-deep-equal-3.1.3/3a7d56b559d6cbc3eb512325244e619a65c6c525.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://npm.buzzfeed.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0/874bf69c6f404c2b5d99c481341399fd55892633.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://npm.buzzfeed.com/fast-levenshtein/-/fast-levenshtein-2.0.6/3d8a5c66883a16a30ca8643e851f19baa7797917.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
-        },
-        "figures": {
-            "version": "3.2.0",
-            "resolved": "https://npm.buzzfeed.com/figures/-/figures-3.2.0/625c18bd293c604dc4a8ddb2febf0c88341746af.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^1.0.5"
-            }
-        },
-        "file-entry-cache": {
-            "version": "5.0.1",
-            "resolved": "https://npm.buzzfeed.com/file-entry-cache/-/file-entry-cache-5.0.1/ca0f6efa6dd3d561333fb14515065c2fafdf439c.tgz",
-            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-            "dev": true,
-            "requires": {
-                "flat-cache": "^2.0.1"
-            }
-        },
-        "flat-cache": {
-            "version": "2.0.1",
-            "resolved": "https://npm.buzzfeed.com/flat-cache/-/flat-cache-2.0.1/5d296d6f04bda44a4630a301413bdbc2ec085ec0.tgz",
-            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-            "dev": true,
-            "requires": {
-                "flatted": "^2.0.0",
-                "rimraf": "2.6.3",
-                "write": "1.0.3"
-            }
-        },
-        "flatted": {
-            "version": "2.0.2",
-            "resolved": "https://npm.buzzfeed.com/flatted/-/flatted-2.0.2/4575b21e2bcee7434aa9be662f4b7b5f9c2b5138.tgz",
-            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-            "dev": true
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://npm.buzzfeed.com/fs.realpath/-/fs.realpath-1.0.0/1504ad2523158caa40db4a2787cb01411994ea4f.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://npm.buzzfeed.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1/1b0ab3bd553b2a0d6399d29c0e3ea0b252078327.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
-        },
-        "glob": {
-            "version": "7.1.6",
-            "resolved": "https://npm.buzzfeed.com/glob/-/glob-7.1.6/141f33b81a7c2492e125594307480c46679278a6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
-            "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            }
-        },
-        "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://npm.buzzfeed.com/glob-parent/-/glob-parent-5.1.1/b6c1ef417c4e5663ea498f1c45afac6916bbc229.tgz",
-            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-            "dev": true,
-            "requires": {
-                "is-glob": "^4.0.1"
-            }
-        },
-        "globals": {
-            "version": "12.4.0",
-            "resolved": "https://npm.buzzfeed.com/globals/-/globals-12.4.0/a18813576a41b00a24a97e7f815918c2e19925f8.tgz",
-            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.8.1"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://npm.buzzfeed.com/has-ansi/-/has-ansi-2.0.0/34f5049ce1ecdf2b0649af3ef24e45ed35416d91.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                }
-            }
+          "version": "1.1.4",
+          "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.4/c2a09a87acbde69543de6f63fa3995c826c536a2.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-3.0.0/b5d454dc2199ae225699f3467e5a07f3b955bafd.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
-        },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://npm.buzzfeed.com/iconv-lite/-/iconv-lite-0.4.24/2022b4b25fbddc21d2f524974a474aafe733908b.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
-        },
-        "ignore": {
-            "version": "4.0.6",
-            "resolved": "https://npm.buzzfeed.com/ignore/-/ignore-4.0.6/750e3db5862087b4737ebac8207ffd1ef27b25fc.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-            "dev": true
-        },
-        "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://npm.buzzfeed.com/import-fresh/-/import-fresh-3.2.1/633ff618506e793af5ac91bf48b72677e15cbe66.tgz",
-            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-            "dev": true,
-            "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://npm.buzzfeed.com/imurmurhash/-/imurmurhash-0.1.4/9218b9b2b928a238b13dc4fb6b6d576f231453ea.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
-        },
-        "indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://npm.buzzfeed.com/indent-string/-/indent-string-4.0.0/624f8f4497d619b2d9768531d58f4122854d7251.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true
-        },
-        "inflight": {
-            "version": "1.0.6",
-            "resolved": "https://npm.buzzfeed.com/inflight/-/inflight-1.0.6/49bd6331d7d02d0c09bc910a1075ba8165b56df9.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
-            "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://npm.buzzfeed.com/inherits/-/inherits-2.0.4/0fa2c64f932917c3433a0ded55363aae37416b7c.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
-        },
-        "inquirer": {
-            "version": "7.3.3",
-            "resolved": "https://npm.buzzfeed.com/inquirer/-/inquirer-7.3.3/04d176b2af04afc157a83fd7c100e98ee0aad003.tgz",
-            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^3.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.19",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.6.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-8.0.0/e818fd69ce5ccfcb404594f842963bf53164cc37.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0/f116f8064fe90b3f7844a38997c0b75051269f1d.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-4.2.0/952182c46cc7b2c313d1596e623992bd163b72b5.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                }
-            }
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://npm.buzzfeed.com/is-extglob/-/is-extglob-2.1.1/a88c02535791f02ed37c76a1b9ea9773c833f8c2.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0/a3b30a5c4f199183167aaab93beefae3ddfb654f.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
-        },
-        "is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://npm.buzzfeed.com/is-glob/-/is-glob-4.0.1/7567dbe9f2f5e2467bc77ab83c4a29482407a5dc.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^2.1.1"
-            }
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://npm.buzzfeed.com/isexe/-/isexe-2.0.0/e8fbf374dc556ff8947a10dcb0572d633f2cfa10.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
-        },
-        "js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://npm.buzzfeed.com/js-tokens/-/js-tokens-4.0.0/19203fb59991df98e3a287050d4647cdeaf32499.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://npm.buzzfeed.com/js-yaml/-/js-yaml-3.14.0/a7a34170f26a21bb162424d8adacb4113a69e482.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://npm.buzzfeed.com/json-schema-traverse/-/json-schema-traverse-0.4.1/69f6a87d9513ab8bb8fe63bdb0979c448e684660.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://npm.buzzfeed.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1/9db7b59496ad3f3cfef30a75142d2d930ad72651.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
-        "levn": {
-            "version": "0.4.1",
-            "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.4.1/ae4562c007473b932a6200d403268dd2fffc6ade.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            }
-        },
-        "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://npm.buzzfeed.com/lodash/-/lodash-4.17.20/b44a9b6297bcb698f1c51a3545a2b3b368d59c52.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
-        },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://npm.buzzfeed.com/lodash.merge/-/lodash.merge-4.6.2/558aa53b43b661e1925a0afdfa36a9a1085fe57a.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "loglevel": {
-            "version": "1.7.0",
-            "resolved": "https://npm.buzzfeed.com/loglevel/-/loglevel-1.7.0/728166855a740d59d38db01cf46f042caa041bb0.tgz",
-            "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
-            "dev": true
-        },
-        "loglevel-colored-level-prefix": {
-            "version": "1.0.0",
-            "resolved": "https://npm.buzzfeed.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0/6a40218fdc7ae15fc76c3d0f3e676c465388603e.tgz",
-            "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "loglevel": "^1.4.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-2.2.1/b432dd3358b634cf75e1e4664368240533c1ddbe.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-1.1.3/a8115c55e4a702fe4d150abd3872822a7e09fc98.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-3.0.1/6a385fb8853d952d5ff05d0e8aaf94278dc63dcf.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-2.0.0/535d045ce6b6363fa40117084629995e9df324c7.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://npm.buzzfeed.com/mimic-fn/-/mimic-fn-2.1.0/7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
-        },
-        "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://npm.buzzfeed.com/minimatch/-/minimatch-3.0.4/5166e286457f03306064be5497e8dbb0c3d32083.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
-        "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://npm.buzzfeed.com/minimist/-/minimist-1.2.5/67d66014b66a6a8aaa0c083c5fd58df4e4e97602.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://npm.buzzfeed.com/mkdirp/-/mkdirp-0.5.5/d91cefd62d1436ca0f41620e251288d420099def.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
-        "ms": {
-            "version": "2.1.2",
-            "resolved": "https://npm.buzzfeed.com/ms/-/ms-2.1.2/d09d1f357b443f493382a8eb3ccd183872ae6009.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "mute-stream": {
-            "version": "0.0.8",
-            "resolved": "https://npm.buzzfeed.com/mute-stream/-/mute-stream-0.0.8/1630c42b2251ff81e2a283de96a5497ea92e5e0d.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-            "dev": true
-        },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://npm.buzzfeed.com/natural-compare/-/natural-compare-1.4.0/4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
-        "nice-try": {
-            "version": "1.0.5",
-            "resolved": "https://npm.buzzfeed.com/nice-try/-/nice-try-1.0.5/a3378a7696ce7d223e88fc9b764bd7ef1089e366.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
-        },
-        "once": {
-            "version": "1.4.0",
-            "resolved": "https://npm.buzzfeed.com/once/-/once-1.4.0/583b1aa775961d4b113ac17d9c50baef9dd76bd1.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
-            "requires": {
-                "wrappy": "1"
-            }
-        },
-        "onetime": {
-            "version": "5.1.2",
-            "resolved": "https://npm.buzzfeed.com/onetime/-/onetime-5.1.2/d0e96ebb56b07476df1dd9c4806e5237985ca45e.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
-            }
-        },
-        "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.9.1/4f236a6373dae0566a6d43e1326674f50c291499.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "requires": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://npm.buzzfeed.com/os-tmpdir/-/os-tmpdir-1.0.2/bbe67406c79aa85c5cfec766fe5734555dfa1274.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
-        },
-        "parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://npm.buzzfeed.com/parent-module/-/parent-module-1.0.1/691d2709e78c79fae3a156622452d00762caaaa2.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "requires": {
-                "callsites": "^3.0.0"
-            }
-        },
-        "path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://npm.buzzfeed.com/path-is-absolute/-/path-is-absolute-1.0.1/174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-key": {
-            "version": "3.1.1",
-            "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-3.1.1/581f6ade658cbba65a0d3380de7753295054f375.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
-        },
-        "prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.2.1/debc6489d7a6e6b0e7611888cec880337d316396.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
-        },
-        "prettier": {
-            "version": "2.1.2",
-            "resolved": "https://npm.buzzfeed.com/prettier/-/prettier-2.1.2/3050700dae2e4c8b67c4c3f666cdb8af405e1ce5.tgz",
-            "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
-            "dev": true
-        },
-        "prettier-eslint": {
-            "version": "11.0.0",
-            "resolved": "https://npm.buzzfeed.com/prettier-eslint/-/prettier-eslint-11.0.0/b19b97c8a1fc4c898b7d1a54b948ef957ceb101d.tgz",
-            "integrity": "sha512-ACjL7T8m10HCO7DwYdXwhNWuZzQv86JkZAhVpzFV9brTMWi3i6LhqoELFaXf6RetDngujz89tnbDmGyvDl+rzA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/parser": "^3.0.0",
-                "common-tags": "^1.4.0",
-                "dlv": "^1.1.0",
-                "eslint": "^6.8.0",
-                "indent-string": "^4.0.0",
-                "lodash.merge": "^4.6.0",
-                "loglevel-colored-level-prefix": "^1.0.0",
-                "prettier": "^2.0.0",
-                "pretty-format": "^23.0.1",
-                "require-relative": "^0.8.7",
-                "typescript": "^3.9.3",
-                "vue-eslint-parser": "~7.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-6.0.5/4a5ec7c64dfae22c3a14124dbacdee846d80cbc4.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://npm.buzzfeed.com/semver/-/semver-5.7.1/a954f931aeba508d307bbf069eff0c01c96116f7.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                            "dev": true
-                        }
-                    }
-                },
-                "eslint": {
-                    "version": "6.8.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-6.8.0/62262d6729739f9275723824302fb227c8c93ffb.tgz",
-                    "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "ajv": "^6.10.0",
-                        "chalk": "^2.1.0",
-                        "cross-spawn": "^6.0.5",
-                        "debug": "^4.0.1",
-                        "doctrine": "^3.0.0",
-                        "eslint-scope": "^5.0.0",
-                        "eslint-utils": "^1.4.3",
-                        "eslint-visitor-keys": "^1.1.0",
-                        "espree": "^6.1.2",
-                        "esquery": "^1.0.1",
-                        "esutils": "^2.0.2",
-                        "file-entry-cache": "^5.0.1",
-                        "functional-red-black-tree": "^1.0.1",
-                        "glob-parent": "^5.0.0",
-                        "globals": "^12.1.0",
-                        "ignore": "^4.0.6",
-                        "import-fresh": "^3.0.0",
-                        "imurmurhash": "^0.1.4",
-                        "inquirer": "^7.0.0",
-                        "is-glob": "^4.0.0",
-                        "js-yaml": "^3.13.1",
-                        "json-stable-stringify-without-jsonify": "^1.0.1",
-                        "levn": "^0.3.0",
-                        "lodash": "^4.17.14",
-                        "minimatch": "^3.0.4",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "optionator": "^0.8.3",
-                        "progress": "^2.0.0",
-                        "regexpp": "^2.0.1",
-                        "semver": "^6.1.2",
-                        "strip-ansi": "^5.2.0",
-                        "strip-json-comments": "^3.0.1",
-                        "table": "^5.2.3",
-                        "text-table": "^0.2.0",
-                        "v8-compile-cache": "^2.0.3"
-                    }
-                },
-                "eslint-utils": {
-                    "version": "1.4.3",
-                    "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-1.4.3/74fec7c54d0776b6f67e0251040b5806564e981f.tgz",
-                    "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-                    "dev": true,
-                    "requires": {
-                        "eslint-visitor-keys": "^1.1.0"
-                    }
-                },
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                },
-                "espree": {
-                    "version": "6.2.1",
-                    "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
-                    "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "^7.1.1",
-                        "acorn-jsx": "^5.2.0",
-                        "eslint-visitor-keys": "^1.1.0"
-                    }
-                },
-                "levn": {
-                    "version": "0.3.0",
-                    "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.3.0/3b09924edf9f083c0490fdd4c0bc4421e04764ee.tgz",
-                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                    }
-                },
-                "optionator": {
-                    "version": "0.8.3",
-                    "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.8.3/84fa1d036fe9d3c7e21d99884b601167ec8fb495.tgz",
-                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-                    "dev": true,
-                    "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.6",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "word-wrap": "~1.2.3"
-                    }
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-2.0.1/411cadb574c5a140d3a4b1910d40d80cc9f40b40.tgz",
-                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-                    "dev": true
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.1.2/21932a549f5e52ffd9a827f570e04be62a97da54.tgz",
-                    "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                    "dev": true
-                },
-                "regexpp": {
-                    "version": "2.0.1",
-                    "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-2.0.1/8d19d31cf632482b589049f8281f93dbcba4d07f.tgz",
-                    "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://npm.buzzfeed.com/semver/-/semver-6.3.0/ee0a64c8af5e8ceea67687b133761e1becbd1d3d.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-1.2.0/44aac65b695b03398968c39f363fee5deafdf1ea.tgz",
-                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-1.0.0/da42f49740c0b42db2ca9728571cb190c98efea3.tgz",
-                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.3.2/5884cab512cf1d355e3fb784f30804b2b520db72.tgz",
-                    "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2"
-                    }
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://npm.buzzfeed.com/which/-/which-1.3.1/a45043d54f5805316da8d62f9f50918d3da70b0a.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                }
-            }
-        },
-        "pretty-format": {
-            "version": "23.6.0",
-            "resolved": "https://npm.buzzfeed.com/pretty-format/-/pretty-format-23.6.0/5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760.tgz",
-            "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-3.0.0/ed0317c322064f79466c02966bddb605ab37d998.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                }
-            }
-        },
-        "progress": {
-            "version": "2.0.3",
-            "resolved": "https://npm.buzzfeed.com/progress/-/progress-2.0.3/7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true
-        },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://npm.buzzfeed.com/punycode/-/punycode-2.1.1/b58b010ac40c22c5657616c8d2c2c02c7bf479ec.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "regexpp": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-3.1.0/206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2.tgz",
-            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-            "dev": true
-        },
-        "require-relative": {
-            "version": "0.8.7",
-            "resolved": "https://npm.buzzfeed.com/require-relative/-/require-relative-0.8.7/7999539fc9e047a37928fa196f8e1563dabd36de.tgz",
-            "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-            "dev": true
-        },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://npm.buzzfeed.com/resolve-from/-/resolve-from-4.0.0/4abcd852ad32dd7baabfe9b40e00a36db5f392e6.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
-        },
-        "restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/restore-cursor/-/restore-cursor-3.1.0/39f67c54b3a7a58cea5236d95cf0034239631f7e.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "requires": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            }
-        },
-        "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://npm.buzzfeed.com/rimraf/-/rimraf-2.6.3/b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
-        },
-        "run-async": {
-            "version": "2.4.1",
-            "resolved": "https://npm.buzzfeed.com/run-async/-/run-async-2.4.1/8440eccf99ea3e70bd409d49aab88e10c189a455.tgz",
-            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-            "dev": true
-        },
-        "rxjs": {
-            "version": "6.6.3",
-            "resolved": "https://npm.buzzfeed.com/rxjs/-/rxjs-6.6.3/8ca84635c4daa900c0d3967a6ee7ac60271ee552.tgz",
-            "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
-            }
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://npm.buzzfeed.com/safer-buffer/-/safer-buffer-2.1.2/44fa161b0187b9549dd84bb91802f9bd8385cd6a.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
-        },
-        "semver": {
-            "version": "7.3.2",
-            "resolved": "https://npm.buzzfeed.com/semver/-/semver-7.3.2/604962b052b81ed0786aae84389ffba70ffd3938.tgz",
-            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-            "dev": true
-        },
-        "shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-2.0.0/ccd0af4f8835fbdc265b82461aaf0c36663f34ea.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "requires": {
-                "shebang-regex": "^3.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-3.0.0/ae16f1644d873ecad843b0307b143362d4c42172.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://npm.buzzfeed.com/signal-exit/-/signal-exit-3.0.3/a1410c2edd8f077b08b4e253c8eacfcaf057461c.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
-        },
-        "slice-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://npm.buzzfeed.com/slice-ansi/-/slice-ansi-2.1.0/cacd7693461a637a5788d92a7dd4fba068e81636.tgz",
-            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.0",
-                "astral-regex": "^1.0.0",
-                "is-fullwidth-code-point": "^2.0.0"
-            }
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://npm.buzzfeed.com/sprintf-js/-/sprintf-js-1.0.3/04e6926f662895354f3dd015203633b857297e2c.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "string-width": {
-            "version": "3.1.0",
-            "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-3.1.0/22767be21b62af1081574306f69ac51b62203961.tgz",
-            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-            "dev": true,
-            "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                }
-            }
-        },
-        "strip-ansi": {
-            "version": "6.0.0",
-            "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-6.0.0/0b1571dd7669ccd4f3e06e14ef1eed26225ae532.tgz",
-            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^5.0.0"
-            }
-        },
-        "strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://npm.buzzfeed.com/strip-json-comments/-/strip-json-comments-3.1.1/31f1281b3832630434831c310c01cccda8cbe006.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true
+          "version": "4.0.0",
+          "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-4.0.0/944771fd9c81c81265c4d6941860da06bb59479b.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-5.5.0/e2e69a44ac8772f78a1ec0b35b689df6530efc8f.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
+          "version": "7.2.0",
+          "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-7.2.0/1b7dcdcb32b8138801b3e478ba6a51caa89648da.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://npm.buzzfeed.com/chardet/-/chardet-0.7.0/90094849f0937f2eedc2425d0d28a9e5f0cbad9e.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/cli-cursor/-/cli-cursor-3.1.0/264305a7ae490d1d03bf0c9ba7c925d1753af307.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://npm.buzzfeed.com/cli-width/-/cli-width-3.0.0/a2f48437a2caa9a22436e794bf071ec9e61cedf6.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-1.9.3/bb71850690e1f136567de629d2d5471deda4c1e8.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.3/a7d0558bd89c42f795dd42328f740831ca53bc25.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://npm.buzzfeed.com/common-tags/-/common-tags-1.8.0/8e3153e542d4a39e9b10554434afaaf98956a937.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://npm.buzzfeed.com/concat-map/-/concat-map-0.0.1/d8a96bd77fd68df7793a73036a3ba0d5405d477b.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-7.0.3/f73a85b9d5d41d045551c177e2882d4ac85728a6.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.2.0",
+      "resolved": "https://npm.buzzfeed.com/debug/-/debug-4.2.0/7f150f93920e94c58f5574c2fd01a3110effe7f1.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://npm.buzzfeed.com/deep-is/-/deep-is-0.1.3/b369d6fb5dbc13eecf524f91b070feedc357cf34.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://npm.buzzfeed.com/dlv/-/dlv-1.1.3/5c198a8a11453596e751494d49874bc7732f2e79.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://npm.buzzfeed.com/doctrine/-/doctrine-3.0.0/addebead72a6574db783639dc87a121773973961.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-7.0.3/933a04052860c85e83c122479c4748a8e4c72156.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://npm.buzzfeed.com/enquirer/-/enquirer-2.3.6/2a7fe5dd634a1e4125a975ec994ff5456dc3734d.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://npm.buzzfeed.com/escape-string-regexp/-/escape-string-regexp-1.0.5/1b61c0562190a8dff6ae3bb2cf0200ca130b86d4.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.11.0",
+      "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-7.11.0/aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b.tgz",
+      "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.1.3",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://npm.buzzfeed.com/eslint-scope/-/eslint-scope-5.1.1/e786e59a66cb92b3f6c1fb0d508aab174848f48c.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-2.1.0/d2de5e03424e707dc10c74068ddedae708741b27.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0/21fdc8fbcd9c795cc0321f0563702095751511a8.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.0",
+      "resolved": "https://npm.buzzfeed.com/espree/-/espree-7.3.0/dc30437cf67947cf576121ebd780f15eeac72348.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://npm.buzzfeed.com/esprima/-/esprima-4.0.1/13b04cdb3e6c5d19df91ab6987a8695619b0aa71.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://npm.buzzfeed.com/esquery/-/esquery-1.3.1/b78b5828aa8e214e29fb74c4d5b752e1c033da57.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://npm.buzzfeed.com/esrecurse/-/esrecurse-4.3.0/7ad7964d679abb28bee72cec63758b1c5d2c9921.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-4.3.0/398ad3f3c5a24948be7725e83d11a7de28cdbd1d.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://npm.buzzfeed.com/esutils/-/esutils-2.0.3/74d2eb4de0b8da1293711910d50775b9b710ef64.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/external-editor/-/external-editor-3.1.0/cb03f740befae03ea4d283caed2741a83f335495.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://npm.buzzfeed.com/fast-deep-equal/-/fast-deep-equal-3.1.3/3a7d56b559d6cbc3eb512325244e619a65c6c525.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://npm.buzzfeed.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0/874bf69c6f404c2b5d99c481341399fd55892633.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://npm.buzzfeed.com/fast-levenshtein/-/fast-levenshtein-2.0.6/3d8a5c66883a16a30ca8643e851f19baa7797917.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://npm.buzzfeed.com/figures/-/figures-3.2.0/625c18bd293c604dc4a8ddb2febf0c88341746af.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://npm.buzzfeed.com/file-entry-cache/-/file-entry-cache-5.0.1/ca0f6efa6dd3d561333fb14515065c2fafdf439c.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://npm.buzzfeed.com/flat-cache/-/flat-cache-2.0.1/5d296d6f04bda44a4630a301413bdbc2ec085ec0.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://npm.buzzfeed.com/flatted/-/flatted-2.0.2/4575b21e2bcee7434aa9be662f4b7b5f9c2b5138.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://npm.buzzfeed.com/fs.realpath/-/fs.realpath-1.0.0/1504ad2523158caa40db4a2787cb01411994ea4f.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://npm.buzzfeed.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1/1b0ab3bd553b2a0d6399d29c0e3ea0b252078327.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://npm.buzzfeed.com/glob/-/glob-7.1.6/141f33b81a7c2492e125594307480c46679278a6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://npm.buzzfeed.com/glob-parent/-/glob-parent-5.1.1/b6c1ef417c4e5663ea498f1c45afac6916bbc229.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://npm.buzzfeed.com/globals/-/globals-12.4.0/a18813576a41b00a24a97e7f815918c2e19925f8.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://npm.buzzfeed.com/has-ansi/-/has-ansi-2.0.0/34f5049ce1ecdf2b0649af3ef24e45ed35416d91.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-3.0.0/b5d454dc2199ae225699f3467e5a07f3b955bafd.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://npm.buzzfeed.com/iconv-lite/-/iconv-lite-0.4.24/2022b4b25fbddc21d2f524974a474aafe733908b.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://npm.buzzfeed.com/ignore/-/ignore-4.0.6/750e3db5862087b4737ebac8207ffd1ef27b25fc.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://npm.buzzfeed.com/import-fresh/-/import-fresh-3.2.1/633ff618506e793af5ac91bf48b72677e15cbe66.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://npm.buzzfeed.com/imurmurhash/-/imurmurhash-0.1.4/9218b9b2b928a238b13dc4fb6b6d576f231453ea.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://npm.buzzfeed.com/indent-string/-/indent-string-4.0.0/624f8f4497d619b2d9768531d58f4122854d7251.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://npm.buzzfeed.com/inflight/-/inflight-1.0.6/49bd6331d7d02d0c09bc910a1075ba8165b56df9.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://npm.buzzfeed.com/inherits/-/inherits-2.0.4/0fa2c64f932917c3433a0ded55363aae37416b7c.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://npm.buzzfeed.com/inquirer/-/inquirer-7.3.3/04d176b2af04afc157a83fd7c100e98ee0aad003.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-8.0.0/e818fd69ce5ccfcb404594f842963bf53164cc37.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0/f116f8064fe90b3f7844a38997c0b75051269f1d.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-4.2.0/952182c46cc7b2c313d1596e623992bd163b72b5.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://npm.buzzfeed.com/is-extglob/-/is-extglob-2.1.1/a88c02535791f02ed37c76a1b9ea9773c833f8c2.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0/a3b30a5c4f199183167aaab93beefae3ddfb654f.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://npm.buzzfeed.com/is-glob/-/is-glob-4.0.1/7567dbe9f2f5e2467bc77ab83c4a29482407a5dc.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://npm.buzzfeed.com/isexe/-/isexe-2.0.0/e8fbf374dc556ff8947a10dcb0572d633f2cfa10.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://npm.buzzfeed.com/js-tokens/-/js-tokens-4.0.0/19203fb59991df98e3a287050d4647cdeaf32499.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://npm.buzzfeed.com/js-yaml/-/js-yaml-3.14.0/a7a34170f26a21bb162424d8adacb4113a69e482.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://npm.buzzfeed.com/json-schema-traverse/-/json-schema-traverse-0.4.1/69f6a87d9513ab8bb8fe63bdb0979c448e684660.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://npm.buzzfeed.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1/9db7b59496ad3f3cfef30a75142d2d930ad72651.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.4.1/ae4562c007473b932a6200d403268dd2fffc6ade.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://npm.buzzfeed.com/lodash/-/lodash-4.17.20/b44a9b6297bcb698f1c51a3545a2b3b368d59c52.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://npm.buzzfeed.com/lodash.merge/-/lodash.merge-4.6.2/558aa53b43b661e1925a0afdfa36a9a1085fe57a.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "loglevel": {
+      "version": "1.7.0",
+      "resolved": "https://npm.buzzfeed.com/loglevel/-/loglevel-1.7.0/728166855a740d59d38db01cf46f042caa041bb0.tgz",
+      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://npm.buzzfeed.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0/6a40218fdc7ae15fc76c3d0f3e676c465388603e.tgz",
+      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-2.2.1/b432dd3358b634cf75e1e4664368240533c1ddbe.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-1.1.3/a8115c55e4a702fe4d150abd3872822a7e09fc98.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-3.0.1/6a385fb8853d952d5ff05d0e8aaf94278dc63dcf.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-2.0.0/535d045ce6b6363fa40117084629995e9df324c7.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://npm.buzzfeed.com/mimic-fn/-/mimic-fn-2.1.0/7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://npm.buzzfeed.com/minimatch/-/minimatch-3.0.4/5166e286457f03306064be5497e8dbb0c3d32083.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://npm.buzzfeed.com/minimist/-/minimist-1.2.5/67d66014b66a6a8aaa0c083c5fd58df4e4e97602.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://npm.buzzfeed.com/mkdirp/-/mkdirp-0.5.5/d91cefd62d1436ca0f41620e251288d420099def.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://npm.buzzfeed.com/ms/-/ms-2.1.2/d09d1f357b443f493382a8eb3ccd183872ae6009.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://npm.buzzfeed.com/mute-stream/-/mute-stream-0.0.8/1630c42b2251ff81e2a283de96a5497ea92e5e0d.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://npm.buzzfeed.com/natural-compare/-/natural-compare-1.4.0/4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://npm.buzzfeed.com/nice-try/-/nice-try-1.0.5/a3378a7696ce7d223e88fc9b764bd7ef1089e366.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://npm.buzzfeed.com/once/-/once-1.4.0/583b1aa775961d4b113ac17d9c50baef9dd76bd1.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://npm.buzzfeed.com/onetime/-/onetime-5.1.2/d0e96ebb56b07476df1dd9c4806e5237985ca45e.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.9.1/4f236a6373dae0566a6d43e1326674f50c291499.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://npm.buzzfeed.com/os-tmpdir/-/os-tmpdir-1.0.2/bbe67406c79aa85c5cfec766fe5734555dfa1274.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://npm.buzzfeed.com/parent-module/-/parent-module-1.0.1/691d2709e78c79fae3a156622452d00762caaaa2.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://npm.buzzfeed.com/path-is-absolute/-/path-is-absolute-1.0.1/174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-3.1.1/581f6ade658cbba65a0d3380de7753295054f375.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.2.1/debc6489d7a6e6b0e7611888cec880337d316396.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://npm.buzzfeed.com/prettier/-/prettier-2.1.2/3050700dae2e4c8b67c4c3f666cdb8af405e1ce5.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
+    "prettier-eslint": {
+      "version": "11.0.0",
+      "resolved": "https://npm.buzzfeed.com/prettier-eslint/-/prettier-eslint-11.0.0/b19b97c8a1fc4c898b7d1a54b948ef957ceb101d.tgz",
+      "integrity": "sha512-ACjL7T8m10HCO7DwYdXwhNWuZzQv86JkZAhVpzFV9brTMWi3i6LhqoELFaXf6RetDngujz89tnbDmGyvDl+rzA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^3.0.0",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^6.8.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^2.0.0",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^3.9.3",
+        "vue-eslint-parser": "~7.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-6.0.5/4a5ec7c64dfae22c3a14124dbacdee846d80cbc4.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://npm.buzzfeed.com/semver/-/semver-5.7.1/a954f931aeba508d307bbf069eff0c01c96116f7.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
             }
+          }
         },
-        "table": {
-            "version": "5.4.6",
-            "resolved": "https://npm.buzzfeed.com/table/-/table-5.4.6/1292d19500ce3f86053b05f0e8e7e4a3bb21079e.tgz",
-            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.10.2",
-                "lodash": "^4.17.14",
-                "slice-ansi": "^2.1.0",
-                "string-width": "^3.0.0"
-            }
+        "eslint": {
+          "version": "6.8.0",
+          "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-6.8.0/62262d6729739f9275723824302fb227c8c93ffb.tgz",
+          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.3",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
         },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://npm.buzzfeed.com/text-table/-/text-table-0.2.0/7f5ee823ae805207c00af2df4a84ec3fcfa570b4.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-1.4.3/74fec7c54d0776b6f67e0251040b5806564e981f.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
         },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://npm.buzzfeed.com/through/-/through-2.3.8/0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
         },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://npm.buzzfeed.com/tmp/-/tmp-0.0.33/6d34335889768d21b2bcda0aa277ced3b1bfadf9.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
         },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://npm.buzzfeed.com/tslib/-/tslib-1.14.1/cf2d38bdc34a134bcaf1091c41f6619e2f672d00.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.3.0/3b09924edf9f083c0490fdd4c0bc4421e04764ee.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
         },
-        "tsutils": {
-            "version": "3.17.1",
-            "resolved": "https://npm.buzzfeed.com/tsutils/-/tsutils-3.17.1/ed719917f11ca0dee586272b2ac49e015a2dd759.tgz",
-            "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.8.3/84fa1d036fe9d3c7e21d99884b601167ec8fb495.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-2.0.1/411cadb574c5a140d3a4b1910d40d80cc9f40b40.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.1.2/21932a549f5e52ffd9a827f570e04be62a97da54.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-2.0.1/8d19d31cf632482b589049f8281f93dbcba4d07f.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://npm.buzzfeed.com/semver/-/semver-6.3.0/ee0a64c8af5e8ceea67687b133761e1becbd1d3d.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-1.2.0/44aac65b695b03398968c39f363fee5deafdf1ea.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-1.0.0/da42f49740c0b42db2ca9728571cb190c98efea3.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         },
         "type-check": {
-            "version": "0.4.0",
-            "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.4.0/07b8203bfa7056c0657050e3ccd2c37730bab8f1.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1"
-            }
-        },
-        "type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.8.1/09e249ebde851d3b1e48d27c105444667f17b83d.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "dev": true
-        },
-        "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://npm.buzzfeed.com/typescript/-/typescript-3.9.7/98d600a5ebdc38f40cb277522f12dc800e9e25fa.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-            "dev": true
-        },
-        "uri-js": {
-            "version": "4.4.0",
-            "resolved": "https://npm.buzzfeed.com/uri-js/-/uri-js-4.4.0/aa714261de793e8a82347a7bcc9ce74e86f28602.tgz",
-            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "v8-compile-cache": {
-            "version": "2.1.1",
-            "resolved": "https://npm.buzzfeed.com/v8-compile-cache/-/v8-compile-cache-2.1.1/54bc3cdd43317bca91e35dcaf305b1a7237de745.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
-            "dev": true
-        },
-        "vue-eslint-parser": {
-            "version": "7.1.1",
-            "resolved": "https://npm.buzzfeed.com/vue-eslint-parser/-/vue-eslint-parser-7.1.1/c43c1c715ff50778b9a7e9a4e16921185f3425d3.tgz",
-            "integrity": "sha512-8FdXi0gieEwh1IprIBafpiJWcApwrU+l2FEj8c1HtHFdNXMd0+2jUSjBVmcQYohf/E72irwAXEXLga6TQcB3FA==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "eslint-scope": "^5.0.0",
-                "eslint-visitor-keys": "^1.1.0",
-                "espree": "^6.2.1",
-                "esquery": "^1.0.1",
-                "lodash": "^4.17.15"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                },
-                "espree": {
-                    "version": "6.2.1",
-                    "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
-                    "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "^7.1.1",
-                        "acorn-jsx": "^5.2.0",
-                        "eslint-visitor-keys": "^1.1.0"
-                    }
-                }
-            }
+          "version": "0.3.2",
+          "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.3.2/5884cab512cf1d355e3fb784f30804b2b520db72.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
         },
         "which": {
-            "version": "2.0.2",
-            "resolved": "https://npm.buzzfeed.com/which/-/which-2.0.2/7c6a8dd0a636a0327e10b59c9286eee93f3f51b1.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "requires": {
-                "isexe": "^2.0.0"
-            }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://npm.buzzfeed.com/word-wrap/-/word-wrap-1.2.3/610636f6b1f703891bd34771ccb17fb93b47079c.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
-        },
-        "wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://npm.buzzfeed.com/wrappy/-/wrappy-1.0.2/b5243d8f3ec1aa35f1364605bc0d1036e30ab69f.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
-        },
-        "write": {
-            "version": "1.0.3",
-            "resolved": "https://npm.buzzfeed.com/write/-/write-1.0.3/0800e14523b923a387e415123c865616aae0f5c3.tgz",
-            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-            "dev": true,
-            "requires": {
-                "mkdirp": "^0.5.1"
-            }
+          "version": "1.3.1",
+          "resolved": "https://npm.buzzfeed.com/which/-/which-1.3.1/a45043d54f5805316da8d62f9f50918d3da70b0a.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
+      }
+    },
+    "pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://npm.buzzfeed.com/pretty-format/-/pretty-format-23.6.0/5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-3.0.0/ed0317c322064f79466c02966bddb605ab37d998.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://npm.buzzfeed.com/progress/-/progress-2.0.3/7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://npm.buzzfeed.com/punycode/-/punycode-2.1.1/b58b010ac40c22c5657616c8d2c2c02c7bf479ec.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-3.1.0/206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://npm.buzzfeed.com/require-relative/-/require-relative-0.8.7/7999539fc9e047a37928fa196f8e1563dabd36de.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://npm.buzzfeed.com/resolve-from/-/resolve-from-4.0.0/4abcd852ad32dd7baabfe9b40e00a36db5f392e6.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/restore-cursor/-/restore-cursor-3.1.0/39f67c54b3a7a58cea5236d95cf0034239631f7e.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://npm.buzzfeed.com/rimraf/-/rimraf-2.6.3/b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://npm.buzzfeed.com/run-async/-/run-async-2.4.1/8440eccf99ea3e70bd409d49aab88e10c189a455.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://npm.buzzfeed.com/rxjs/-/rxjs-6.6.3/8ca84635c4daa900c0d3967a6ee7ac60271ee552.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://npm.buzzfeed.com/safer-buffer/-/safer-buffer-2.1.2/44fa161b0187b9549dd84bb91802f9bd8385cd6a.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://npm.buzzfeed.com/semver/-/semver-7.3.2/604962b052b81ed0786aae84389ffba70ffd3938.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-2.0.0/ccd0af4f8835fbdc265b82461aaf0c36663f34ea.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-3.0.0/ae16f1644d873ecad843b0307b143362d4c42172.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://npm.buzzfeed.com/signal-exit/-/signal-exit-3.0.3/a1410c2edd8f077b08b4e253c8eacfcaf057461c.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://npm.buzzfeed.com/slice-ansi/-/slice-ansi-2.1.0/cacd7693461a637a5788d92a7dd4fba068e81636.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://npm.buzzfeed.com/sprintf-js/-/sprintf-js-1.0.3/04e6926f662895354f3dd015203633b857297e2c.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-3.1.0/22767be21b62af1081574306f69ac51b62203961.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-6.0.0/0b1571dd7669ccd4f3e06e14ef1eed26225ae532.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://npm.buzzfeed.com/strip-json-comments/-/strip-json-comments-3.1.1/31f1281b3832630434831c310c01cccda8cbe006.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-5.5.0/e2e69a44ac8772f78a1ec0b35b689df6530efc8f.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://npm.buzzfeed.com/table/-/table-5.4.6/1292d19500ce3f86053b05f0e8e7e4a3bb21079e.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://npm.buzzfeed.com/text-table/-/text-table-0.2.0/7f5ee823ae805207c00af2df4a84ec3fcfa570b4.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://npm.buzzfeed.com/through/-/through-2.3.8/0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://npm.buzzfeed.com/tmp/-/tmp-0.0.33/6d34335889768d21b2bcda0aa277ced3b1bfadf9.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://npm.buzzfeed.com/tslib/-/tslib-1.14.1/cf2d38bdc34a134bcaf1091c41f6619e2f672d00.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://npm.buzzfeed.com/tsutils/-/tsutils-3.17.1/ed719917f11ca0dee586272b2ac49e015a2dd759.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.4.0/07b8203bfa7056c0657050e3ccd2c37730bab8f1.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.8.1/09e249ebde851d3b1e48d27c105444667f17b83d.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://npm.buzzfeed.com/typescript/-/typescript-3.9.7/98d600a5ebdc38f40cb277522f12dc800e9e25fa.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://npm.buzzfeed.com/uri-js/-/uri-js-4.4.0/aa714261de793e8a82347a7bcc9ce74e86f28602.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://npm.buzzfeed.com/v8-compile-cache/-/v8-compile-cache-2.1.1/54bc3cdd43317bca91e35dcaf305b1a7237de745.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
+    "vue-eslint-parser": {
+      "version": "7.1.1",
+      "resolved": "https://npm.buzzfeed.com/vue-eslint-parser/-/vue-eslint-parser-7.1.1/c43c1c715ff50778b9a7e9a4e16921185f3425d3.tgz",
+      "integrity": "sha512-8FdXi0gieEwh1IprIBafpiJWcApwrU+l2FEj8c1HtHFdNXMd0+2jUSjBVmcQYohf/E72irwAXEXLga6TQcB3FA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.2.1",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://npm.buzzfeed.com/which/-/which-2.0.2/7c6a8dd0a636a0327e10b59c9286eee93f3f51b1.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://npm.buzzfeed.com/word-wrap/-/word-wrap-1.2.3/610636f6b1f703891bd34771ccb17fb93b47079c.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://npm.buzzfeed.com/wrappy/-/wrappy-1.0.2/b5243d8f3ec1aa35f1364605bc0d1036e30ab69f.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://npm.buzzfeed.com/write/-/write-1.0.3/0800e14523b923a387e415123c865616aae0f5c3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,914 @@
+{
+    "name": "homebridge-rituals",
+    "version": "1.1.9",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.10.4",
+            "resolved": "https://npm.buzzfeed.com/@babel/code-frame/-/code-frame-7.10.4/168da1a36e90da68ae8d49c0f1b48c7c6249213a.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.4",
+            "resolved": "https://npm.buzzfeed.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4/a78c7a7251e01f616512d31b10adcf52ada5e0d2.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+            "dev": true
+        },
+        "@babel/highlight": {
+            "version": "7.10.4",
+            "resolved": "https://npm.buzzfeed.com/@babel/highlight/-/highlight-7.10.4/7d1bdfd65753538fabe6c38596cdb76d9ac60143.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                }
+            }
+        },
+        "@eslint/eslintrc": {
+            "version": "0.1.3",
+            "resolved": "https://npm.buzzfeed.com/@eslint/eslintrc/-/eslintrc-0.1.3/7d1a2b2358552cc04834c0979bd4275362e37085.tgz",
+            "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            }
+        },
+        "acorn": {
+            "version": "7.4.1",
+            "resolved": "https://npm.buzzfeed.com/acorn/-/acorn-7.4.1/feaed255973d2e77555b83dbc08851a6c63520fa.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.3.1",
+            "resolved": "https://npm.buzzfeed.com/acorn-jsx/-/acorn-jsx-5.3.1/fc8661e11b7ac1539c47dbfea2e72b3af34d267b.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://npm.buzzfeed.com/ajv/-/ajv-6.12.6/baf5a62e802b07d977034586f8c3baf5adf26df4.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://npm.buzzfeed.com/ansi-colors/-/ansi-colors-4.1.1/cbb9ae256bf750af1eab344f229aa27fe94ba348.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-5.0.0/388539f55179bf39339c81af30a654d69f87cb75.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-3.2.1/41fbb20243e50b12be0f04b8dedbf07520ce841d.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://npm.buzzfeed.com/argparse/-/argparse-1.0.10/bcd6791ea5ae09725e17e5ad988134cd40b3d911.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://npm.buzzfeed.com/astral-regex/-/astral-regex-1.0.0/6c8c3fb827dd43ee3918f27b82782ab7658a6fd9.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://npm.buzzfeed.com/balanced-match/-/balanced-match-1.0.0/89b4d199ab2bee49de164ea02b89ce462d71b767.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://npm.buzzfeed.com/brace-expansion/-/brace-expansion-1.1.11/3c7fcbf529d87226f3d2f52b966ff5271eb441dd.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/callsites/-/callsites-3.1.0/b3630abd8943432f54b3f0519238e33cd7df2f73.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "4.1.0",
+            "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-4.1.0/4e14870a618d9e2edd97dd8345fd9d9dc315646a.tgz",
+            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-4.3.0/edd803628ae71c04c85ae7a0906edad34b648937.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-2.0.1/72d3a68d598c9bdb3af2ad1e84f21d896abd4de3.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.4/c2a09a87acbde69543de6f63fa3995c826c536a2.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-4.0.0/944771fd9c81c81265c4d6941860da06bb59479b.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-7.2.0/1b7dcdcb32b8138801b3e478ba6a51caa89648da.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-1.9.3/bb71850690e1f136567de629d2d5471deda4c1e8.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.3/a7d0558bd89c42f795dd42328f740831ca53bc25.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://npm.buzzfeed.com/concat-map/-/concat-map-0.0.1/d8a96bd77fd68df7793a73036a3ba0d5405d477b.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-7.0.3/f73a85b9d5d41d045551c177e2882d4ac85728a6.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            }
+        },
+        "debug": {
+            "version": "4.2.0",
+            "resolved": "https://npm.buzzfeed.com/debug/-/debug-4.2.0/7f150f93920e94c58f5574c2fd01a3110effe7f1.tgz",
+            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://npm.buzzfeed.com/deep-is/-/deep-is-0.1.3/b369d6fb5dbc13eecf524f91b070feedc357cf34.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://npm.buzzfeed.com/doctrine/-/doctrine-3.0.0/addebead72a6574db783639dc87a121773973961.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-7.0.3/933a04052860c85e83c122479c4748a8e4c72156.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://npm.buzzfeed.com/enquirer/-/enquirer-2.3.6/2a7fe5dd634a1e4125a975ec994ff5456dc3734d.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://npm.buzzfeed.com/escape-string-regexp/-/escape-string-regexp-1.0.5/1b61c0562190a8dff6ae3bb2cf0200ca130b86d4.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "7.11.0",
+            "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-7.11.0/aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b.tgz",
+            "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@eslint/eslintrc": "^0.1.3",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^2.0.0",
+                "espree": "^7.3.0",
+                "esquery": "^1.2.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "progress": "^2.0.0",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            }
+        },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://npm.buzzfeed.com/eslint-scope/-/eslint-scope-5.1.1/e786e59a66cb92b3f6c1fb0d508aab174848f48c.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "2.1.0",
+            "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-2.1.0/d2de5e03424e707dc10c74068ddedae708741b27.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "2.0.0",
+            "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0/21fdc8fbcd9c795cc0321f0563702095751511a8.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "7.3.0",
+            "resolved": "https://npm.buzzfeed.com/espree/-/espree-7.3.0/dc30437cf67947cf576121ebd780f15eeac72348.tgz",
+            "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.2.0",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://npm.buzzfeed.com/esprima/-/esprima-4.0.1/13b04cdb3e6c5d19df91ab6987a8695619b0aa71.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.3.1",
+            "resolved": "https://npm.buzzfeed.com/esquery/-/esquery-1.3.1/b78b5828aa8e214e29fb74c4d5b752e1c033da57.tgz",
+            "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
+            }
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://npm.buzzfeed.com/esrecurse/-/esrecurse-4.3.0/7ad7964d679abb28bee72cec63758b1c5d2c9921.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-5.2.0/307df42547e6cc7324d3cf03c155d5cdb8c53880.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://npm.buzzfeed.com/estraverse/-/estraverse-4.3.0/398ad3f3c5a24948be7725e83d11a7de28cdbd1d.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://npm.buzzfeed.com/esutils/-/esutils-2.0.3/74d2eb4de0b8da1293711910d50775b9b710ef64.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://npm.buzzfeed.com/fast-deep-equal/-/fast-deep-equal-3.1.3/3a7d56b559d6cbc3eb512325244e619a65c6c525.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://npm.buzzfeed.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0/874bf69c6f404c2b5d99c481341399fd55892633.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://npm.buzzfeed.com/fast-levenshtein/-/fast-levenshtein-2.0.6/3d8a5c66883a16a30ca8643e851f19baa7797917.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "file-entry-cache": {
+            "version": "5.0.1",
+            "resolved": "https://npm.buzzfeed.com/file-entry-cache/-/file-entry-cache-5.0.1/ca0f6efa6dd3d561333fb14515065c2fafdf439c.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^2.0.1"
+            }
+        },
+        "flat-cache": {
+            "version": "2.0.1",
+            "resolved": "https://npm.buzzfeed.com/flat-cache/-/flat-cache-2.0.1/5d296d6f04bda44a4630a301413bdbc2ec085ec0.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+            "dev": true,
+            "requires": {
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            }
+        },
+        "flatted": {
+            "version": "2.0.2",
+            "resolved": "https://npm.buzzfeed.com/flatted/-/flatted-2.0.2/4575b21e2bcee7434aa9be662f4b7b5f9c2b5138.tgz",
+            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://npm.buzzfeed.com/fs.realpath/-/fs.realpath-1.0.0/1504ad2523158caa40db4a2787cb01411994ea4f.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://npm.buzzfeed.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1/1b0ab3bd553b2a0d6399d29c0e3ea0b252078327.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://npm.buzzfeed.com/glob/-/glob-7.1.6/141f33b81a7c2492e125594307480c46679278a6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "5.1.1",
+            "resolved": "https://npm.buzzfeed.com/glob-parent/-/glob-parent-5.1.1/b6c1ef417c4e5663ea498f1c45afac6916bbc229.tgz",
+            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "globals": {
+            "version": "12.4.0",
+            "resolved": "https://npm.buzzfeed.com/globals/-/globals-12.4.0/a18813576a41b00a24a97e7f815918c2e19925f8.tgz",
+            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.8.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-3.0.0/b5d454dc2199ae225699f3467e5a07f3b955bafd.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://npm.buzzfeed.com/ignore/-/ignore-4.0.6/750e3db5862087b4737ebac8207ffd1ef27b25fc.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.2.1",
+            "resolved": "https://npm.buzzfeed.com/import-fresh/-/import-fresh-3.2.1/633ff618506e793af5ac91bf48b72677e15cbe66.tgz",
+            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://npm.buzzfeed.com/imurmurhash/-/imurmurhash-0.1.4/9218b9b2b928a238b13dc4fb6b6d576f231453ea.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://npm.buzzfeed.com/inflight/-/inflight-1.0.6/49bd6331d7d02d0c09bc910a1075ba8165b56df9.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://npm.buzzfeed.com/inherits/-/inherits-2.0.4/0fa2c64f932917c3433a0ded55363aae37416b7c.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://npm.buzzfeed.com/is-extglob/-/is-extglob-2.1.1/a88c02535791f02ed37c76a1b9ea9773c833f8c2.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0/a3b30a5c4f199183167aaab93beefae3ddfb654f.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://npm.buzzfeed.com/is-glob/-/is-glob-4.0.1/7567dbe9f2f5e2467bc77ab83c4a29482407a5dc.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://npm.buzzfeed.com/isexe/-/isexe-2.0.0/e8fbf374dc556ff8947a10dcb0572d633f2cfa10.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://npm.buzzfeed.com/js-tokens/-/js-tokens-4.0.0/19203fb59991df98e3a287050d4647cdeaf32499.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://npm.buzzfeed.com/js-yaml/-/js-yaml-3.14.0/a7a34170f26a21bb162424d8adacb4113a69e482.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://npm.buzzfeed.com/json-schema-traverse/-/json-schema-traverse-0.4.1/69f6a87d9513ab8bb8fe63bdb0979c448e684660.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://npm.buzzfeed.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1/9db7b59496ad3f3cfef30a75142d2d930ad72651.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.4.1",
+            "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.4.1/ae4562c007473b932a6200d403268dd2fffc6ade.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.20",
+            "resolved": "https://npm.buzzfeed.com/lodash/-/lodash-4.17.20/b44a9b6297bcb698f1c51a3545a2b3b368d59c52.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://npm.buzzfeed.com/minimatch/-/minimatch-3.0.4/5166e286457f03306064be5497e8dbb0c3d32083.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://npm.buzzfeed.com/minimist/-/minimist-1.2.5/67d66014b66a6a8aaa0c083c5fd58df4e4e97602.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://npm.buzzfeed.com/mkdirp/-/mkdirp-0.5.5/d91cefd62d1436ca0f41620e251288d420099def.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://npm.buzzfeed.com/ms/-/ms-2.1.2/d09d1f357b443f493382a8eb3ccd183872ae6009.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://npm.buzzfeed.com/natural-compare/-/natural-compare-1.4.0/4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://npm.buzzfeed.com/once/-/once-1.4.0/583b1aa775961d4b113ac17d9c50baef9dd76bd1.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optionator": {
+            "version": "0.9.1",
+            "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.9.1/4f236a6373dae0566a6d43e1326674f50c291499.tgz",
+            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "dev": true,
+            "requires": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
+            }
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://npm.buzzfeed.com/parent-module/-/parent-module-1.0.1/691d2709e78c79fae3a156622452d00762caaaa2.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://npm.buzzfeed.com/path-is-absolute/-/path-is-absolute-1.0.1/174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-3.1.1/581f6ade658cbba65a0d3380de7753295054f375.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.2.1/debc6489d7a6e6b0e7611888cec880337d316396.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://npm.buzzfeed.com/progress/-/progress-2.0.3/7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://npm.buzzfeed.com/punycode/-/punycode-2.1.1/b58b010ac40c22c5657616c8d2c2c02c7bf479ec.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "regexpp": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-3.1.0/206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://npm.buzzfeed.com/resolve-from/-/resolve-from-4.0.0/4abcd852ad32dd7baabfe9b40e00a36db5f392e6.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://npm.buzzfeed.com/rimraf/-/rimraf-2.6.3/b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "semver": {
+            "version": "7.3.2",
+            "resolved": "https://npm.buzzfeed.com/semver/-/semver-7.3.2/604962b052b81ed0786aae84389ffba70ffd3938.tgz",
+            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-2.0.0/ccd0af4f8835fbdc265b82461aaf0c36663f34ea.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-3.0.0/ae16f1644d873ecad843b0307b143362d4c42172.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://npm.buzzfeed.com/slice-ansi/-/slice-ansi-2.1.0/cacd7693461a637a5788d92a7dd4fba068e81636.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://npm.buzzfeed.com/sprintf-js/-/sprintf-js-1.0.3/04e6926f662895354f3dd015203633b857297e2c.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-3.1.0/22767be21b62af1081574306f69ac51b62203961.tgz",
+            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-6.0.0/0b1571dd7669ccd4f3e06e14ef1eed26225ae532.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^5.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://npm.buzzfeed.com/strip-json-comments/-/strip-json-comments-3.1.1/31f1281b3832630434831c310c01cccda8cbe006.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-5.5.0/e2e69a44ac8772f78a1ec0b35b689df6530efc8f.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "table": {
+            "version": "5.4.6",
+            "resolved": "https://npm.buzzfeed.com/table/-/table-5.4.6/1292d19500ce3f86053b05f0e8e7e4a3bb21079e.tgz",
+            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://npm.buzzfeed.com/text-table/-/text-table-0.2.0/7f5ee823ae805207c00af2df4a84ec3fcfa570b4.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.4.0",
+            "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.4.0/07b8203bfa7056c0657050e3ccd2c37730bab8f1.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1"
+            }
+        },
+        "type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.8.1/09e249ebde851d3b1e48d27c105444667f17b83d.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.4.0",
+            "resolved": "https://npm.buzzfeed.com/uri-js/-/uri-js-4.4.0/aa714261de793e8a82347a7bcc9ce74e86f28602.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "v8-compile-cache": {
+            "version": "2.1.1",
+            "resolved": "https://npm.buzzfeed.com/v8-compile-cache/-/v8-compile-cache-2.1.1/54bc3cdd43317bca91e35dcaf305b1a7237de745.tgz",
+            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+            "dev": true
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://npm.buzzfeed.com/which/-/which-2.0.2/7c6a8dd0a636a0327e10b59c9286eee93f3f51b1.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://npm.buzzfeed.com/word-wrap/-/word-wrap-1.2.3/610636f6b1f703891bd34771ccb17fb93b47079c.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://npm.buzzfeed.com/wrappy/-/wrappy-1.0.2/b5243d8f3ec1aa35f1364605bc0d1036e30ab69f.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "1.0.3",
+            "resolved": "https://npm.buzzfeed.com/write/-/write-1.0.3/0800e14523b923a387e415123c865616aae0f5c3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,91 @@
                 "strip-json-comments": "^3.1.1"
             }
         },
+        "@types/eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://npm.buzzfeed.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0/1ee30d79544ca84d68d4b3cdb0af4f205663dd2d.tgz",
+            "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+            "dev": true
+        },
+        "@types/json-schema": {
+            "version": "7.0.6",
+            "resolved": "https://npm.buzzfeed.com/@types/json-schema/-/json-schema-7.0.6/f4c7ec43e81b319a9815115031709f26987891f0.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "dev": true
+        },
+        "@typescript-eslint/experimental-utils": {
+            "version": "3.10.1",
+            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1/e179ffc81a80ebcae2ea04e0332f8b251345a686.tgz",
+            "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/types": "3.10.1",
+                "@typescript-eslint/typescript-estree": "3.10.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "3.10.1",
+            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/parser/-/parser-3.10.1/1883858e83e8b442627e1ac6f408925211155467.tgz",
+            "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
+            "dev": true,
+            "requires": {
+                "@types/eslint-visitor-keys": "^1.0.0",
+                "@typescript-eslint/experimental-utils": "3.10.1",
+                "@typescript-eslint/types": "3.10.1",
+                "@typescript-eslint/typescript-estree": "3.10.1",
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "3.10.1",
+            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/types/-/types-3.10.1/1d7463fa7c32d8a23ab508a803ca2fe26e758727.tgz",
+            "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "3.10.1",
+            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1/fd0061cc38add4fad45136d654408569f365b853.tgz",
+            "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "3.10.1",
+                "@typescript-eslint/visitor-keys": "3.10.1",
+                "debug": "^4.1.1",
+                "glob": "^7.1.6",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "3.10.1",
+            "resolved": "https://npm.buzzfeed.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1/cd4274773e3eb63b2e870ac602274487ecd1e931.tgz",
+            "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://npm.buzzfeed.com/acorn/-/acorn-7.4.1/feaed255973d2e77555b83dbc08851a6c63520fa.tgz",
@@ -90,6 +175,23 @@
             "resolved": "https://npm.buzzfeed.com/ansi-colors/-/ansi-colors-4.1.1/cbb9ae256bf750af1eab344f229aa27fe94ba348.tgz",
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
+        },
+        "ansi-escapes": {
+            "version": "4.3.1",
+            "resolved": "https://npm.buzzfeed.com/ansi-escapes/-/ansi-escapes-4.3.1/a5c47cc43181f1f38ffd7076837700d395522a61.tgz",
+            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.11.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.11.0/97abf0872310fed88a5c466b25681576145e33f1.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
+            }
         },
         "ansi-regex": {
             "version": "5.0.0",
@@ -194,6 +296,27 @@
                 }
             }
         },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://npm.buzzfeed.com/chardet/-/chardet-0.7.0/90094849f0937f2eedc2425d0d28a9e5f0cbad9e.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/cli-cursor/-/cli-cursor-3.1.0/264305a7ae490d1d03bf0c9ba7c925d1753af307.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^3.1.0"
+            }
+        },
+        "cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://npm.buzzfeed.com/cli-width/-/cli-width-3.0.0/a2f48437a2caa9a22436e794bf071ec9e61cedf6.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://npm.buzzfeed.com/color-convert/-/color-convert-1.9.3/bb71850690e1f136567de629d2d5471deda4c1e8.tgz",
@@ -207,6 +330,12 @@
             "version": "1.1.3",
             "resolved": "https://npm.buzzfeed.com/color-name/-/color-name-1.1.3/a7d0558bd89c42f795dd42328f740831ca53bc25.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "common-tags": {
+            "version": "1.8.0",
+            "resolved": "https://npm.buzzfeed.com/common-tags/-/common-tags-1.8.0/8e3153e542d4a39e9b10554434afaaf98956a937.tgz",
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
             "dev": true
         },
         "concat-map": {
@@ -239,6 +368,12 @@
             "version": "0.1.3",
             "resolved": "https://npm.buzzfeed.com/deep-is/-/deep-is-0.1.3/b369d6fb5dbc13eecf524f91b070feedc357cf34.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "dlv": {
+            "version": "1.1.3",
+            "resolved": "https://npm.buzzfeed.com/dlv/-/dlv-1.1.3/5c198a8a11453596e751494d49874bc7732f2e79.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true
         },
         "doctrine": {
@@ -420,6 +555,17 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/external-editor/-/external-editor-3.1.0/cb03f740befae03ea4d283caed2741a83f335495.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            }
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://npm.buzzfeed.com/fast-deep-equal/-/fast-deep-equal-3.1.3/3a7d56b559d6cbc3eb512325244e619a65c6c525.tgz",
@@ -437,6 +583,15 @@
             "resolved": "https://npm.buzzfeed.com/fast-levenshtein/-/fast-levenshtein-2.0.6/3d8a5c66883a16a30ca8643e851f19baa7797917.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "figures": {
+            "version": "3.2.0",
+            "resolved": "https://npm.buzzfeed.com/figures/-/figures-3.2.0/625c18bd293c604dc4a8ddb2febf0c88341746af.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
         },
         "file-entry-cache": {
             "version": "5.0.1",
@@ -508,11 +663,37 @@
                 "type-fest": "^0.8.1"
             }
         },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://npm.buzzfeed.com/has-ansi/-/has-ansi-2.0.0/34f5049ce1ecdf2b0649af3ef24e45ed35416d91.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                }
+            }
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://npm.buzzfeed.com/has-flag/-/has-flag-3.0.0/b5d454dc2199ae225699f3467e5a07f3b955bafd.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://npm.buzzfeed.com/iconv-lite/-/iconv-lite-0.4.24/2022b4b25fbddc21d2f524974a474aafe733908b.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
         },
         "ignore": {
             "version": "4.0.6",
@@ -536,6 +717,12 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://npm.buzzfeed.com/indent-string/-/indent-string-4.0.0/624f8f4497d619b2d9768531d58f4122854d7251.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://npm.buzzfeed.com/inflight/-/inflight-1.0.6/49bd6331d7d02d0c09bc910a1075ba8165b56df9.tgz",
@@ -551,6 +738,52 @@
             "resolved": "https://npm.buzzfeed.com/inherits/-/inherits-2.0.4/0fa2c64f932917c3433a0ded55363aae37416b7c.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "inquirer": {
+            "version": "7.3.3",
+            "resolved": "https://npm.buzzfeed.com/inquirer/-/inquirer-7.3.3/04d176b2af04afc157a83fd7c100e98ee0aad003.tgz",
+            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.19",
+                "mute-stream": "0.0.8",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://npm.buzzfeed.com/emoji-regex/-/emoji-regex-8.0.0/e818fd69ce5ccfcb404594f842963bf53164cc37.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://npm.buzzfeed.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0/f116f8064fe90b3f7844a38997c0b75051269f1d.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://npm.buzzfeed.com/string-width/-/string-width-4.2.0/952182c46cc7b2c313d1596e623992bd163b72b5.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
+            }
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -623,6 +856,76 @@
             "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
             "dev": true
         },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://npm.buzzfeed.com/lodash.merge/-/lodash.merge-4.6.2/558aa53b43b661e1925a0afdfa36a9a1085fe57a.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "loglevel": {
+            "version": "1.7.0",
+            "resolved": "https://npm.buzzfeed.com/loglevel/-/loglevel-1.7.0/728166855a740d59d38db01cf46f042caa041bb0.tgz",
+            "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+            "dev": true
+        },
+        "loglevel-colored-level-prefix": {
+            "version": "1.0.0",
+            "resolved": "https://npm.buzzfeed.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0/6a40218fdc7ae15fc76c3d0f3e676c465388603e.tgz",
+            "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "loglevel": "^1.4.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-2.1.1/c3b33ab5ee360d86e0e628f0468ae7ef27d654df.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://npm.buzzfeed.com/ansi-styles/-/ansi-styles-2.2.1/b432dd3358b634cf75e1e4664368240533c1ddbe.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-1.1.3/a8115c55e4a702fe4d150abd3872822a7e09fc98.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-3.0.1/6a385fb8853d952d5ff05d0e8aaf94278dc63dcf.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://npm.buzzfeed.com/supports-color/-/supports-color-2.0.0/535d045ce6b6363fa40117084629995e9df324c7.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://npm.buzzfeed.com/mimic-fn/-/mimic-fn-2.1.0/7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://npm.buzzfeed.com/minimatch/-/minimatch-3.0.4/5166e286457f03306064be5497e8dbb0c3d32083.tgz",
@@ -653,10 +956,22 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://npm.buzzfeed.com/mute-stream/-/mute-stream-0.0.8/1630c42b2251ff81e2a283de96a5497ea92e5e0d.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "dev": true
+        },
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://npm.buzzfeed.com/natural-compare/-/natural-compare-1.4.0/4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://npm.buzzfeed.com/nice-try/-/nice-try-1.0.5/a3378a7696ce7d223e88fc9b764bd7ef1089e366.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
         "once": {
@@ -666,6 +981,15 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "5.1.2",
+            "resolved": "https://npm.buzzfeed.com/onetime/-/onetime-5.1.2/d0e96ebb56b07476df1dd9c4806e5237985ca45e.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^2.1.0"
             }
         },
         "optionator": {
@@ -681,6 +1005,12 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
             }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://npm.buzzfeed.com/os-tmpdir/-/os-tmpdir-1.0.2/bbe67406c79aa85c5cfec766fe5734555dfa1274.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
         },
         "parent-module": {
             "version": "1.0.1",
@@ -709,6 +1039,251 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
+        "prettier": {
+            "version": "2.1.2",
+            "resolved": "https://npm.buzzfeed.com/prettier/-/prettier-2.1.2/3050700dae2e4c8b67c4c3f666cdb8af405e1ce5.tgz",
+            "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+            "dev": true
+        },
+        "prettier-eslint": {
+            "version": "11.0.0",
+            "resolved": "https://npm.buzzfeed.com/prettier-eslint/-/prettier-eslint-11.0.0/b19b97c8a1fc4c898b7d1a54b948ef957ceb101d.tgz",
+            "integrity": "sha512-ACjL7T8m10HCO7DwYdXwhNWuZzQv86JkZAhVpzFV9brTMWi3i6LhqoELFaXf6RetDngujz89tnbDmGyvDl+rzA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/parser": "^3.0.0",
+                "common-tags": "^1.4.0",
+                "dlv": "^1.1.0",
+                "eslint": "^6.8.0",
+                "indent-string": "^4.0.0",
+                "lodash.merge": "^4.6.0",
+                "loglevel-colored-level-prefix": "^1.0.0",
+                "prettier": "^2.0.0",
+                "pretty-format": "^23.0.1",
+                "require-relative": "^0.8.7",
+                "typescript": "^3.9.3",
+                "vue-eslint-parser": "~7.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-4.1.0/8b9f8f08cf1acb843756a839ca8c7e3168c51997.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://npm.buzzfeed.com/chalk/-/chalk-2.4.2/cd42541677a54333cf541a49108c1432b44c9424.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://npm.buzzfeed.com/cross-spawn/-/cross-spawn-6.0.5/4a5ec7c64dfae22c3a14124dbacdee846d80cbc4.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://npm.buzzfeed.com/semver/-/semver-5.7.1/a954f931aeba508d307bbf069eff0c01c96116f7.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "eslint": {
+                    "version": "6.8.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint/-/eslint-6.8.0/62262d6729739f9275723824302fb227c8c93ffb.tgz",
+                    "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "ajv": "^6.10.0",
+                        "chalk": "^2.1.0",
+                        "cross-spawn": "^6.0.5",
+                        "debug": "^4.0.1",
+                        "doctrine": "^3.0.0",
+                        "eslint-scope": "^5.0.0",
+                        "eslint-utils": "^1.4.3",
+                        "eslint-visitor-keys": "^1.1.0",
+                        "espree": "^6.1.2",
+                        "esquery": "^1.0.1",
+                        "esutils": "^2.0.2",
+                        "file-entry-cache": "^5.0.1",
+                        "functional-red-black-tree": "^1.0.1",
+                        "glob-parent": "^5.0.0",
+                        "globals": "^12.1.0",
+                        "ignore": "^4.0.6",
+                        "import-fresh": "^3.0.0",
+                        "imurmurhash": "^0.1.4",
+                        "inquirer": "^7.0.0",
+                        "is-glob": "^4.0.0",
+                        "js-yaml": "^3.13.1",
+                        "json-stable-stringify-without-jsonify": "^1.0.1",
+                        "levn": "^0.3.0",
+                        "lodash": "^4.17.14",
+                        "minimatch": "^3.0.4",
+                        "mkdirp": "^0.5.1",
+                        "natural-compare": "^1.4.0",
+                        "optionator": "^0.8.3",
+                        "progress": "^2.0.0",
+                        "regexpp": "^2.0.1",
+                        "semver": "^6.1.2",
+                        "strip-ansi": "^5.2.0",
+                        "strip-json-comments": "^3.0.1",
+                        "table": "^5.2.3",
+                        "text-table": "^0.2.0",
+                        "v8-compile-cache": "^2.0.3"
+                    }
+                },
+                "eslint-utils": {
+                    "version": "1.4.3",
+                    "resolved": "https://npm.buzzfeed.com/eslint-utils/-/eslint-utils-1.4.3/74fec7c54d0776b6f67e0251040b5806564e981f.tgz",
+                    "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "espree": {
+                    "version": "6.2.1",
+                    "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
+                    "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^7.1.1",
+                        "acorn-jsx": "^5.2.0",
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "levn": {
+                    "version": "0.3.0",
+                    "resolved": "https://npm.buzzfeed.com/levn/-/levn-0.3.0/3b09924edf9f083c0490fdd4c0bc4421e04764ee.tgz",
+                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2"
+                    }
+                },
+                "optionator": {
+                    "version": "0.8.3",
+                    "resolved": "https://npm.buzzfeed.com/optionator/-/optionator-0.8.3/84fa1d036fe9d3c7e21d99884b601167ec8fb495.tgz",
+                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+                    "dev": true,
+                    "requires": {
+                        "deep-is": "~0.1.3",
+                        "fast-levenshtein": "~2.0.6",
+                        "levn": "~0.3.0",
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2",
+                        "word-wrap": "~1.2.3"
+                    }
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://npm.buzzfeed.com/path-key/-/path-key-2.0.1/411cadb574c5a140d3a4b1910d40d80cc9f40b40.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                },
+                "prelude-ls": {
+                    "version": "1.1.2",
+                    "resolved": "https://npm.buzzfeed.com/prelude-ls/-/prelude-ls-1.1.2/21932a549f5e52ffd9a827f570e04be62a97da54.tgz",
+                    "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                    "dev": true
+                },
+                "regexpp": {
+                    "version": "2.0.1",
+                    "resolved": "https://npm.buzzfeed.com/regexpp/-/regexpp-2.0.1/8d19d31cf632482b589049f8281f93dbcba4d07f.tgz",
+                    "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://npm.buzzfeed.com/semver/-/semver-6.3.0/ee0a64c8af5e8ceea67687b133761e1becbd1d3d.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://npm.buzzfeed.com/shebang-command/-/shebang-command-1.2.0/44aac65b695b03398968c39f363fee5deafdf1ea.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-1.0.0/da42f49740c0b42db2ca9728571cb190c98efea3.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://npm.buzzfeed.com/strip-ansi/-/strip-ansi-5.2.0/8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "type-check": {
+                    "version": "0.3.2",
+                    "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.3.2/5884cab512cf1d355e3fb784f30804b2b520db72.tgz",
+                    "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "~1.1.2"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://npm.buzzfeed.com/which/-/which-1.3.1/a45043d54f5805316da8d62f9f50918d3da70b0a.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "pretty-format": {
+            "version": "23.6.0",
+            "resolved": "https://npm.buzzfeed.com/pretty-format/-/pretty-format-23.6.0/5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760.tgz",
+            "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://npm.buzzfeed.com/ansi-regex/-/ansi-regex-3.0.0/ed0317c322064f79466c02966bddb605ab37d998.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                }
+            }
+        },
         "progress": {
             "version": "2.0.3",
             "resolved": "https://npm.buzzfeed.com/progress/-/progress-2.0.3/7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8.tgz",
@@ -727,11 +1302,27 @@
             "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
+        "require-relative": {
+            "version": "0.8.7",
+            "resolved": "https://npm.buzzfeed.com/require-relative/-/require-relative-0.8.7/7999539fc9e047a37928fa196f8e1563dabd36de.tgz",
+            "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+            "dev": true
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://npm.buzzfeed.com/resolve-from/-/resolve-from-4.0.0/4abcd852ad32dd7baabfe9b40e00a36db5f392e6.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
+        },
+        "restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://npm.buzzfeed.com/restore-cursor/-/restore-cursor-3.1.0/39f67c54b3a7a58cea5236d95cf0034239631f7e.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            }
         },
         "rimraf": {
             "version": "2.6.3",
@@ -741,6 +1332,27 @@
             "requires": {
                 "glob": "^7.1.3"
             }
+        },
+        "run-async": {
+            "version": "2.4.1",
+            "resolved": "https://npm.buzzfeed.com/run-async/-/run-async-2.4.1/8440eccf99ea3e70bd409d49aab88e10c189a455.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true
+        },
+        "rxjs": {
+            "version": "6.6.3",
+            "resolved": "https://npm.buzzfeed.com/rxjs/-/rxjs-6.6.3/8ca84635c4daa900c0d3967a6ee7ac60271ee552.tgz",
+            "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://npm.buzzfeed.com/safer-buffer/-/safer-buffer-2.1.2/44fa161b0187b9549dd84bb91802f9bd8385cd6a.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "semver": {
             "version": "7.3.2",
@@ -761,6 +1373,12 @@
             "version": "3.0.0",
             "resolved": "https://npm.buzzfeed.com/shebang-regex/-/shebang-regex-3.0.0/ae16f1644d873ecad843b0307b143362d4c42172.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://npm.buzzfeed.com/signal-exit/-/signal-exit-3.0.3/a1410c2edd8f077b08b4e253c8eacfcaf057461c.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
             "dev": true
         },
         "slice-ansi": {
@@ -850,6 +1468,36 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://npm.buzzfeed.com/through/-/through-2.3.8/0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://npm.buzzfeed.com/tmp/-/tmp-0.0.33/6d34335889768d21b2bcda0aa277ced3b1bfadf9.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "tslib": {
+            "version": "1.14.1",
+            "resolved": "https://npm.buzzfeed.com/tslib/-/tslib-1.14.1/cf2d38bdc34a134bcaf1091c41f6619e2f672d00.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "tsutils": {
+            "version": "3.17.1",
+            "resolved": "https://npm.buzzfeed.com/tsutils/-/tsutils-3.17.1/ed719917f11ca0dee586272b2ac49e015a2dd759.tgz",
+            "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://npm.buzzfeed.com/type-check/-/type-check-0.4.0/07b8203bfa7056c0657050e3ccd2c37730bab8f1.tgz",
@@ -863,6 +1511,12 @@
             "version": "0.8.1",
             "resolved": "https://npm.buzzfeed.com/type-fest/-/type-fest-0.8.1/09e249ebde851d3b1e48d27c105444667f17b83d.tgz",
             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.9.7",
+            "resolved": "https://npm.buzzfeed.com/typescript/-/typescript-3.9.7/98d600a5ebdc38f40cb277522f12dc800e9e25fa.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
             "dev": true
         },
         "uri-js": {
@@ -879,6 +1533,39 @@
             "resolved": "https://npm.buzzfeed.com/v8-compile-cache/-/v8-compile-cache-2.1.1/54bc3cdd43317bca91e35dcaf305b1a7237de745.tgz",
             "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
             "dev": true
+        },
+        "vue-eslint-parser": {
+            "version": "7.1.1",
+            "resolved": "https://npm.buzzfeed.com/vue-eslint-parser/-/vue-eslint-parser-7.1.1/c43c1c715ff50778b9a7e9a4e16921185f3425d3.tgz",
+            "integrity": "sha512-8FdXi0gieEwh1IprIBafpiJWcApwrU+l2FEj8c1HtHFdNXMd0+2jUSjBVmcQYohf/E72irwAXEXLga6TQcB3FA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-visitor-keys": "^1.1.0",
+                "espree": "^6.2.1",
+                "esquery": "^1.0.1",
+                "lodash": "^4.17.15"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://npm.buzzfeed.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0/30ebd1ef7c2fdff01c3a4f151044af25fab0523e.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "espree": {
+                    "version": "6.2.1",
+                    "resolved": "https://npm.buzzfeed.com/espree/-/espree-6.2.1/77fc72e1fd744a2052c20f38a5b575832e82734a.tgz",
+                    "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^7.1.1",
+                        "acorn-jsx": "^5.2.0",
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                }
+            }
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,37 +1,37 @@
 {
-    "name": "homebridge-rituals",
-    "version": "1.1.9",
-    "description": "Rituals plugin for homebridge: https://github.com/nfarina/homebridge",
-    "license": "ISC",
-    "keywords": [
-        "homebridge-plugin",
-        "homebridge",
-        "homebridge-rituals",
-        "rituals",
-        "genie",
-        "homebridge-plugin-rituals",
-        "homekit"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/myluna08/homebridge-rituals.git"
-    },
-    "bugs": {
-        "url": "http://github.com/myluna08/homebridge-rituals/issues"
-    },
-    "author": "Victor Montes",
-    "engines": {
-        "node": ">=0.12.0",
-        "homebridge": ">=0.2.0"
-    },
-    "dependencies": {
-        "request": "^2.88.0",
-        "request-json": "^0.6.4",
-        "node-storage": "^0.0.9"
-    },
-    "homepage": "https://github.com/myluna08/homebridge-rituals#readme",
-    "devDependencies": {
-        "eslint": "^7.11.0",
-        "prettier-eslint": "^11.0.0"
-    }
+  "name": "homebridge-rituals",
+  "version": "1.1.10",
+  "description": "Rituals plugin for homebridge: https://github.com/nfarina/homebridge",
+  "license": "ISC",
+  "keywords": [
+    "homebridge-plugin",
+    "homebridge",
+    "homebridge-rituals",
+    "rituals",
+    "genie",
+    "homebridge-plugin-rituals",
+    "homekit"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/myluna08/homebridge-rituals.git"
+  },
+  "bugs": {
+    "url": "http://github.com/myluna08/homebridge-rituals/issues"
+  },
+  "author": "Victor Montes",
+  "engines": {
+    "node": ">=0.12.0",
+    "homebridge": ">=0.2.0"
+  },
+  "dependencies": {
+    "request": "^2.88.0",
+    "request-json": "^0.6.4",
+    "node-storage": "^0.0.9"
+  },
+  "homepage": "https://github.com/myluna08/homebridge-rituals#readme",
+  "devDependencies": {
+    "eslint": "^7.11.0",
+    "prettier-eslint": "^11.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
     "description": "Rituals plugin for homebridge: https://github.com/nfarina/homebridge",
     "license": "ISC",
     "keywords": [
-        "homebridge-plugin", "homebridge", "homebridge-rituals", "rituals", "genie", "homebridge-plugin-rituals", "homekit"
+        "homebridge-plugin",
+        "homebridge",
+        "homebridge-rituals",
+        "rituals",
+        "genie",
+        "homebridge-plugin-rituals",
+        "homekit"
     ],
     "repository": {
         "type": "git",
@@ -23,5 +29,8 @@
         "request-json": "^0.6.4",
         "node-storage": "^0.0.9"
     },
-    "homepage": "https://github.com/myluna08/homebridge-rituals#readme"
+    "homepage": "https://github.com/myluna08/homebridge-rituals#readme",
+    "devDependencies": {
+        "eslint": "^7.11.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "homepage": "https://github.com/myluna08/homebridge-rituals#readme",
     "devDependencies": {
-        "eslint": "^7.11.0"
+        "eslint": "^7.11.0",
+        "prettier-eslint": "^11.0.0"
     }
 }


### PR DESCRIPTION
Standardises the code layout and also fixes another bug (`callback(undefined, fan_speed);` -> `callback(undefined, that.fan_speed);`)

With .eslintrc.js installed, editors like VS Code will automatically lint your code. This is a big change and I don't mind if you don't merge - it'll just make life easier for other contributors like me.

Also updates version number, corrects the README formatting a little.